### PR TITLE
init: Add sanity check before setting .text upper bound

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -445,7 +445,7 @@ impl Function {
                     if pointer_value >= last_function_address {
                         continue;
                     }
-                    if pointer_value >= start_address {
+                    if pointer_value >= start_address && pointer_value >= address {
                         let offset = (pointer_value - base_addr) as usize;
                         if offset < module_code.len() {
                             let thumb = Function::is_thumb_function(pointer_value, &module_code[offset..]);


### PR DESCRIPTION
Before seeing a constant and assuming it's a pointer to .data and setting the upper bound of .text to that value, we check to be sure this constant wouldn't point to earlier within the region we already know is .text, because that can only be a fake pointer lookalike.

This fixes #8 for DoS. It won't necessarily fix similar issues for all games, since it's still possible for a fake pointer lookalike that appears after the current address but before the real end of .text to slip through, but I haven't encountered any games like this so far.

(This PR combined with the `--allow-unknown-function-calls` flag allows init to run with no errors for DoS, though DoS is still not fully compatible because there are tons of seemingly unrelated problems with the analysis that result in delink erroring instead.)