### PR TITLE
init: Pad addresses in symbols.txt to 8 hex digits

### DIFF
--- a/src/config/symbol.rs
+++ b/src/config/symbol.rs
@@ -545,7 +545,7 @@ impl Symbol {
 
 impl Display for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} kind:{} addr:{:#x}", self.name, self.kind, self.addr)?;
+        write!(f, "{} kind:{} addr:0x{:08x}", self.name, self.kind, self.addr)?;
         if self.ambiguous {
             write!(f, " ambiguous")?;
         }


### PR DESCRIPTION
Most of the addresses output by dsd are padded with a leading 0 so that they're 8 bytes long, including the ones in the auto-generated names in symbols.txt (e.g. `func_0208d4c0`) as well as the from and to fields in relocs.txt.

The addr field in symbols.txt is the odd one out, only being 7 digits long, which makes it a bit annoying to copy-paste and Ctrl+F for since you have to either remove the 0x or add the extra 0 manually.

I changed it so init writes symbol addresses as 8 digits for consistency.