### PR TITLE
Fix objdiff command not allowing the `--c-flags` and `--custom-args` arguments to have a hyphen for their value's first character

### DIFF
--- a/src/cmd/objdiff.rs
+++ b/src/cmd/objdiff.rs
@@ -39,7 +39,7 @@ pub struct Objdiff {
     compiler: Option<String>,
 
     /// Flags to pass to the compiler in decomp.me.
-    #[arg(long, short = 'f')]
+    #[arg(long, short = 'f', allow_hyphen_values = true)]
     c_flags: Option<String>,
 
     /// Preset ID to use in decomp.me.

--- a/src/cmd/objdiff.rs
+++ b/src/cmd/objdiff.rs
@@ -51,7 +51,7 @@ pub struct Objdiff {
     custom_make: Option<String>,
 
     /// Arguments to custom build command.
-    #[arg(long, short = 'M')]
+    #[arg(long, short = 'M', allow_hyphen_values = true)]
     custom_args: Vec<String>,
 }
 


### PR DESCRIPTION
dsd 0.3.0 gives this error:
`error: unexpected argument '-O' found`
when running the objdiff command because it thinks the value of `--c-flags` is its own new argument due to the hyphen.

Fixed with this option: https://docs.rs/clap/2.29.0/clap/struct.Arg.html#method.allow_hyphen_values

I assume the same issue affects the `--custom-args` argument too.
