### PR TITLE
init: Fix improper handling of main function when it is in Thumb mode

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -258,6 +258,7 @@ impl Function {
         let mut functions = BTreeMap::new();
 
         let start_address = search_options.start_address.unwrap_or(base_address);
+        assert!((start_address & 1) == 0);
         let start_offset = start_address - base_address;
         let end_address = search_options.end_address.unwrap_or(base_address + module_code.len() as u32);
         let end_offset = end_address - base_address;

--- a/src/analysis/main.rs
+++ b/src/analysis/main.rs
@@ -49,7 +49,7 @@ impl MainFunction {
         let function_code = function.code(module_code, base_address);
         let tail_call_data = &function_code[(p_tail_call - function.start_address()) as usize..];
         let tail_call = u32::from_le_bytes([tail_call_data[0], tail_call_data[1], tail_call_data[2], tail_call_data[3]]);
-        Ok(tail_call)
+        Ok(tail_call & !1)
     }
 
     pub fn find_in_arm9(arm9: &Arm9) -> Result<Self> {


### PR DESCRIPTION
Some games (e.g. Ghost Trick, Pokemon SoulSilver, Summon Knight) have their main function in Thumb mode, which dsd doesn't handle properly, resulting in the following error in the function `rename_by_address`:
```
Error: No symbol at 0x2000ca5 to rename to 'main'
```

In addition to clearing the lsb of the main function address to fix the bug, I also added an assert to `find_functions` that the lsb is not set in order to make future bugs like this more obvious, as `find_functions` doesn't handle this situation well - it tries to read the misaligned bytes as instructions, which results in a bunch of invalid instructions, but no error in that function.