### PR TITLE
chore: update ds-rom and unarm to upstream version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,8 +532,7 @@ dependencies = [
 [[package]]
 name = "ds-rom"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8febb8319d0bfa20d85a0dd9f851b581a54d4d88076e45abded3b923413a09"
+source = "git+https://github.com/AetiasHax/ds-rom.git?branch=main#6744bb922411b32d79e0a10714cd388c72108b11"
 dependencies = [
  "bitfield-struct",
  "bitreader",
@@ -2122,9 +2121,8 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unarm"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d4cd0e401dbe85923b5ea4ad957bf15010fbc360e187f7df1f9109922a610e3"
+version = "1.6.7"
+source = "git+https://github.com/AetiasHax/unarm?branch=main#2aa6b3141fbedf89c4df83e03b148f1288934b5a"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ petgraph = { version = "0.6", default-features = false }
 serde = "1.0"
 serde_yml = "0.0"
 snafu = { version = "0.8", features = ["backtrace"] }
-unarm = { git = "https://github.com/AetiasHax/unarm", branch = "main", default-features = false, features = ["arm", "thumb", "v5te"] }
+unarm = { git = "https://github.com/AetiasHax/unarm.git", branch = "main", default-features = false, features = ["arm", "thumb", "v5te"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 anyhow = "1.0"
 argp = "0.3"
 bon = "3.0"
-ds-rom = "0.4"
+ds-rom = { git = "https://github.com/AetiasHax/ds-rom.git", branch = "main" }
 env_logger = "0.11"
 fxhash = "0.2"
 globset = "0.4"
@@ -30,7 +30,7 @@ petgraph = { version = "0.6", default-features = false }
 serde = "1.0"
 serde_yml = "0.0"
 snafu = { version = "0.8", features = ["backtrace"] }
-unarm = { version = "1.6", default-features = false, features = ["arm", "thumb", "v5te"] }
+unarm = { git = "https://github.com/AetiasHax/unarm", branch = "main", default-features = false, features = ["arm", "thumb", "v5te"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }


### PR DESCRIPTION
The [ds-rom](https://github.com/AetiasHax/ds-rom) and [unarm](https://github.com/AetiasHax/unarm) dependencies are often updated.

Since `dsd` depends on those two heavily, it probably need to depends on the upstream version so we can the latest change when a new change is merged on one of the dependencies.