### PR TITLE
Basic Err catch when unwrapping function

### DIFF
--- a/cli/src/analysis/data.rs
+++ b/cli/src/analysis/data.rs
@@ -137,7 +137,11 @@ fn add_function_calls_as_relocations(
         } else {
             let candidates = modules.iter().filter(|&module| {
                 let symbol_map = symbol_maps.get(module.kind()).unwrap();
-                let Some((function, _)) = symbol_map.get_function(called_function.address).unwrap() else {
+                let function = symbol_map.get_function(called_function.address);
+                if function.is_err() {
+                    return false;
+                }
+                let Some((function, _)) = function.unwrap() else {
                     return false;
                 };
                 function.mode.into_thumb() == Some(called_function.thumb)


### PR DESCRIPTION
I created an extremely simple error catcher for something I was running into with issue #25. I literally started learning Rust yesterday just to do this, so it may not be Rust-ful, but it seems to solve the issue.