### PR TITLE
Add macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: write
     steps:
@@ -76,6 +76,12 @@ jobs:
         with:
           pattern: dsd-*
           path: artifacts
+
+      - name: Create macOS Universal Binary
+        shell: sh
+        run: |
+          lipo -create -output dsd-macos-universal dsd-macos-x86_64 dsd-macos-arm64
+          rm dsd-macos-x86_64 dsd-macos-arm64
 
       - name: Upload release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,16 @@ jobs:
             target: x86_64-pc-windows-msvc
             file: dsd-windows-x86_64.exe
 
+          - os: macos-latest
+            name: macos-arm64
+            target: aarch64-apple-darwin
+            file: dsd-macos-arm64
+
+          - os: macos-13
+            name: macos-x86_64
+            target: x86_64-apple-darwin
+            file: dsd-macos-x86_64
+
           - os: ubuntu-latest
             name: linux-x86_64
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,8 +80,8 @@ jobs:
       - name: Create macOS Universal Binary
         shell: sh
         run: |
-          lipo -create -output dsd-macos-universal dsd-macos-x86_64 dsd-macos-arm64
-          rm dsd-macos-x86_64 dsd-macos-arm64
+          lipo -create -output artifacts/dsd-macos-universal artifacts/dsd-macos-x86_64 artifacts/dsd-macos-arm64
+          rm artifacts/dsd-macos-x86_64 artifacts/dsd-macos-arm64
 
       - name: Upload release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
   release:
     needs: build
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
@@ -76,12 +76,6 @@ jobs:
         with:
           pattern: dsd-*
           path: artifacts
-
-      - name: Create macOS Universal Binary
-        shell: sh
-        run: |
-          lipo -create -output artifacts/dsd-macos-universal artifacts/dsd-macos-x86_64 artifacts/dsd-macos-arm64
-          rm artifacts/dsd-macos-x86_64 artifacts/dsd-macos-arm64
 
       - name: Upload release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This PR adds both x86 and ARM runners to the GitHub Action to generate both the x86 and ARM binaries.