### PR TITLE
objdiff: Only set base_path if base file exists

### DIFF
--- a/cli/src/cmd/objdiff.rs
+++ b/cli/src/cmd/objdiff.rs
@@ -193,14 +193,12 @@ impl Objdiff {
                 let base_path = if file.gap() {
                     None
                 } else {
-                    Some(
-                        config_path
-                            .join(&config.build_path)
-                            .join(file_path)
-                            .with_extension("o")
-                            .clean_diff_paths(abs_output_path)?
-                            .to_utf8_unix_path_buf(),
-                    )
+                    let base_path = config_path
+                        .join(&config.build_path)
+                        .join(file_path)
+                        .with_extension("o")
+                        .clean_diff_paths(abs_output_path)?;
+                    base_path.exists().then(|| base_path.to_utf8_unix_path_buf())
                 };
 
                 let scratch = if !file.gap() && self.scratch {


### PR DESCRIPTION
`dsd objdiff` would set the `base_path` field for every non-gap delink file, even if it doesn't exist. This causes `objdiff-cli report` to fail to generate a report because it expected the base file to exist.