### PR TITLE
Stable delink sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,6 @@ dependencies = [
  "path-clean",
  "path-slash",
  "pathdiff",
- "petgraph",
  "ratatui",
  "reqwest",
  "serde",
@@ -913,12 +912,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flagset"
@@ -2037,17 +2030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset 0.5.7",
- "hashbrown 0.15.5",
- "indexmap",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,7 +3086,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset 0.4.2",
+ "fixedbitset",
  "hex",
  "lazy_static",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,7 +35,6 @@ object = { git = "https://github.com/AetiasHax/object.git", branch = "dev", defa
 path-clean = "1.0"
 path-slash = "0.2"
 pathdiff = "0.2"
-petgraph = { version = "0.8", default-features = false }
 serde = "1.0"
 serde_json = "1.0"
 serde-saphyr = "0.0"

--- a/cli/src/config/delinks.rs
+++ b/cli/src/config/delinks.rs
@@ -35,6 +35,9 @@ trait DelinksPrivExt {
 
 impl DelinksExt for Delinks {
     fn sort_files(&mut self) -> Result<()> {
+        // Presort to ensure the toposort is stable by giving it the same initial state every time
+        self.files.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+
         let mut graph = Graph::<(), ()>::new();
 
         for _ in 0..self.files.len() {

--- a/cli/src/config/delinks.rs
+++ b/cli/src/config/delinks.rs
@@ -1,5 +1,4 @@
 use std::{
-    cmp::Ordering,
     collections::{BTreeMap, HashMap},
     ops::Range,
     path::Path,
@@ -14,7 +13,8 @@ use ds_decomp::config::{
     section::{MigrateSection, Section, SectionInheritOptions, Sections},
 };
 use ds_rom::rom::raw::AutoloadKind;
-use petgraph::{Graph, graph::NodeIndex};
+
+use crate::util::toposort::toposort;
 
 pub trait DelinksExt
 where
@@ -24,7 +24,6 @@ where
     fn generate_gap_files(&mut self) -> Result<()>;
 }
 trait DelinksPrivExt {
-    fn compare_files(&self, a: &DelinkFile, b: &DelinkFile) -> Ordering;
     fn validate_files(&self) -> Result<()>;
     fn migrate_section(
         &mut self,
@@ -35,52 +34,57 @@ trait DelinksPrivExt {
 
 impl DelinksExt for Delinks {
     fn sort_files(&mut self) -> Result<()> {
-        // Presort to ensure the toposort is stable by giving it the same initial state every time
-        self.files.sort_unstable_by(|a, b| a.name.cmp(&b.name));
-
-        let mut graph = Graph::<(), ()>::new();
-
-        for _ in 0..self.files.len() {
-            graph.add_node(());
+        // Make lists of delink indices for each section, sorted by start address for that section
+        let mut files_sorted_by_section: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+        for (i, file) in self.files.iter().enumerate() {
+            for section in file.sections.iter() {
+                files_sorted_by_section.entry(section.name()).or_default().push(i);
+            }
+        }
+        for (section_name, files) in files_sorted_by_section.iter_mut() {
+            files.sort_unstable_by_key(|&i| {
+                self.files[i].sections.by_name(section_name).unwrap().1.start_address()
+            });
         }
 
-        for i in 0..self.files.len() {
-            let i_node = NodeIndex::new(i);
-            for j in i + 1..self.files.len() {
-                let j_node = NodeIndex::new(j);
-                match self.compare_files(&self.files[i], &self.files[j]) {
-                    Ordering::Less => {
-                        graph.add_edge(i_node, j_node, ());
-                    }
-                    Ordering::Equal => {}
-                    Ordering::Greater => {
-                        graph.add_edge(j_node, i_node, ());
-                    }
-                }
+        // Create edges in link order graph between adjacent delinks
+        let mut graph = vec![Vec::new(); self.files.len()];
+        for files in files_sorted_by_section.values() {
+            for pair in files.windows(2) {
+                graph[pair[0]].push(pair[1]);
             }
         }
 
-        let Ok(mut nodes) = petgraph::algo::toposort(&graph, None) else {
-            bail!("Cycle detected when sorting delink files")
-        };
-
-        // Sort by node indices
-        for i in 0..self.files.len() {
-            if nodes[i].index() != i {
-                let mut current = i;
-                loop {
-                    let target = nodes[current].index();
-                    nodes[current] = NodeIndex::new(current);
-                    if nodes[target] == NodeIndex::new(target) {
-                        break;
-                    }
-                    self.files.swap(current, target);
-                    current = target;
+        // Compute link order
+        match toposort(&graph) {
+            Ok(sorted) => {
+                // Sort delinks by their position in the link order
+                let mut sorted_files = vec![DelinkFile::default(); sorted.len()];
+                for (pos, index) in sorted.into_iter().enumerate() {
+                    sorted_files[pos] = std::mem::take(&mut self.files[index]);
                 }
+                self.files = sorted_files;
+
+                Ok(())
+            }
+            Err(cycle) => {
+                // Print link order cycle
+                let first = cycle[0];
+                let cycle = cycle.into_iter().map(|i| &self.files[i].name).fold(
+                    String::new(),
+                    |mut acc, name| {
+                        acc.push_str(name);
+                        acc.push_str(" -> ");
+                        acc
+                    },
+                );
+                bail!(
+                    "Link order cycle detected while sorting delink files: {}{}",
+                    cycle,
+                    self.files[first].name
+                )
             }
         }
-
-        Ok(())
     }
 
     fn generate_gap_files(&mut self) -> Result<()> {
@@ -151,22 +155,6 @@ impl DelinksExt for Delinks {
 }
 
 impl DelinksPrivExt for Delinks {
-    fn compare_files(&self, a: &DelinkFile, b: &DelinkFile) -> Ordering {
-        for section in self.sections.iter() {
-            let Some((_, a_section)) = a.sections.by_name(section.name()) else {
-                continue;
-            };
-            let Some((_, b_section)) = b.sections.by_name(section.name()) else {
-                continue;
-            };
-            let ordering = a_section.start_address().cmp(&b_section.start_address());
-            if ordering.is_ne() {
-                return ordering;
-            }
-        }
-        Ordering::Equal
-    }
-
     /// Checks that adjacent files do not overlap and that their sections are in ascending order. Assumes that the files list
     /// is already sorted using [`Self::sort_files`].
     fn validate_files(&self) -> Result<()> {

--- a/cli/src/util/mod.rs
+++ b/cli/src/util/mod.rs
@@ -5,3 +5,4 @@ pub mod object;
 pub mod parse;
 pub mod path;
 pub mod serde_hex;
+pub mod toposort;

--- a/cli/src/util/toposort.rs
+++ b/cli/src/util/toposort.rs
@@ -1,0 +1,117 @@
+/// Topological sort algorithm based on DFS:
+/// https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
+/// Finds either an ordering of the vertices such that all edges go from
+/// lower to higher indexed nodes, or a cycle.
+///
+/// Implementation by Simon Lindholm
+/// https://gist.github.com/simonlindholm/08664dd783ad4b9f23532fdd5e352b42
+pub fn toposort(graph: &[Vec<usize>]) -> Result<Vec<usize>, Vec<usize>> {
+    let n = graph.len();
+    #[derive(Copy, Clone)]
+    enum State {
+        Unvisited,
+        Active(usize, usize),
+        Finished,
+    }
+    let mut state = vec![State::Unvisited; n + 1];
+    state[n] = State::Active(0, usize::MAX);
+    let mut ret = Vec::new();
+    let mut cur = n;
+    loop {
+        let State::Active(eind, par) = state[cur] else { panic!("unexpected state 1") };
+        let adj;
+        if cur == n {
+            if eind == n {
+                break;
+            }
+            adj = eind;
+        } else {
+            if eind == graph[cur].len() {
+                state[cur] = State::Finished;
+                ret.push(cur);
+                cur = par;
+                continue;
+            }
+            adj = graph[cur][eind];
+        };
+        state[cur] = State::Active(eind + 1, par);
+        match state[adj] {
+            State::Unvisited => {
+                state[adj] = State::Active(0, cur);
+                cur = adj;
+            }
+            State::Active(..) => {
+                let mut cycle = Vec::new();
+                while cur != adj {
+                    cycle.push(cur);
+                    let State::Active(_, par) = state[cur] else { panic!("unexpected state 2") };
+                    cur = par;
+                }
+                cycle.push(cur);
+                cycle.reverse();
+                return Err(cycle);
+            }
+            State::Finished => {}
+        };
+    }
+    ret.reverse();
+    Ok(ret)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn test_correct() {
+        let mut rng_state: usize = 0;
+        let mut rand = || {
+            rng_state = rng_state.wrapping_mul(123156351724123181_usize);
+            rng_state = rng_state.wrapping_add(670143798154186239_usize);
+            rng_state >> 32
+        };
+        for _ in 0..10000 {
+            let n = rand() % 20;
+            let mut g = vec![vec![]; n];
+            let mut g_set = HashSet::new();
+            if n != 0 {
+                let m = rand() % 50;
+                for _ in 0..m {
+                    let a = rand() % n;
+                    let b = rand() % n;
+                    g[a].push(b);
+                    g_set.insert((a, b));
+                }
+            }
+            match toposort(&g) {
+                Ok(order) => {
+                    assert_eq!(order.len(), n);
+                    let mut node_to_order = vec![usize::MAX; n];
+                    // Every node should occur exactly once...
+                    for (i, &node) in order.iter().enumerate() {
+                        assert!(node < n);
+                        assert_eq!(node_to_order[node], usize::MAX);
+                        node_to_order[node] = i;
+                    }
+                    // and the edges should go in forward order in the list
+                    for i in 0..n {
+                        for &j in &g[i] {
+                            assert!(node_to_order[i] < node_to_order[j]);
+                        }
+                    }
+                }
+                Err(cycle) => {
+                    // The found cycle should exist in the graph
+                    assert!(!cycle.is_empty());
+                    for i in 0..cycle.len() {
+                        let a = cycle[i];
+                        let b = cycle[(i + 1) % cycle.len()];
+                        assert!(g_set.contains(&(a, b)));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lib/src/config/delinks.rs
+++ b/lib/src/config/delinks.rs
@@ -300,6 +300,21 @@ impl Display for DelinkFile {
     }
 }
 
+impl Default for DelinkFile {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            sections: Sections::new(),
+            migrated_sections: Sections::new(),
+            complete: false,
+            categories: Categories::default(),
+            gap: false,
+            migrated: false,
+            comments: Comments::default(),
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Categories {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]


### PR DESCRIPTION
On each operation on delinks.txt, dsd could rearrange delink files with equivalent link order, which had the effect of making delink files bounce between two locations in the file.

This was caused by the toposort implementation being unstable in that output order is dependent on input order. To mitigate this, the input is now fully stable and deterministic by using a different method of computing graph edges (which also generates fewer redundant edges).

Unrelated to this, the toposort implementation has also been replaced with [this one](https://gist.github.com/simonlindholm/08664dd783ad4b9f23532fdd5e352b42) which not only detects cycles (like the old implementation) but also returns the elements in the cycle.

All in all this should make the sorting algorithm stable and have better performance, going from O(n²) average case to O(n) average case.