### PR TITLE
objdiff: `--skip-absent-objects` flag for skipping base object exists

### DIFF
--- a/cli/src/cmd/objdiff.rs
+++ b/cli/src/cmd/objdiff.rs
@@ -52,6 +52,10 @@ pub struct Objdiff {
     /// Arguments to custom build command.
     #[arg(long, short = 'M', allow_hyphen_values = true)]
     custom_args: Vec<String>,
+
+    /// Omits `base_path` for units that have not been compiled.
+    #[arg(long)]
+    skip_absent_objects: bool,
 }
 
 impl Objdiff {
@@ -198,7 +202,11 @@ impl Objdiff {
                         .join(file_path)
                         .with_extension("o")
                         .clean_diff_paths(abs_output_path)?;
-                    base_path.exists().then(|| base_path.to_utf8_unix_path_buf())
+                    if !self.skip_absent_objects || base_path.exists() {
+                        Some(base_path.to_utf8_unix_path_buf())
+                    } else {
+                        None
+                    }
                 };
 
                 let scratch = if !file.gap() && self.scratch {


### PR DESCRIPTION
#57 modified `dsd objdiff` to omit the `base_path` key if it points to a non-existent file. However, this means that a decomp build system has to compile every source file before objdiff.json is generated, otherwise you can't see a comparison between delinked and decompiled code. This can take a long time, for instance when making changes to a commonly used header file.

This feature can still be useful when generating an objdiff progress report, as it lets you skip diffing objects that haven't been made yet. So it made the most sense to add a command-line option for this use case.