### PR TITLE
`weak` symbol attribute

### DIFF
--- a/cli/src/analysis/data.rs
+++ b/cli/src/analysis/data.rs
@@ -263,7 +263,7 @@ fn find_symbol_candidates(
                 }
             }
             if let Some((_, symbol)) = symbol_map.by_address(pointer).unwrap()
-                && symbol.local
+                && symbol.scope.is_local()
             {
                 // Existing symbol is local, so it can't be referred to by a relocation
                 None

--- a/cli/src/cmd/apply.rs
+++ b/cli/src/cmd/apply.rs
@@ -122,20 +122,20 @@ impl Apply {
                 );
                 changed = true;
             }
-            if target_symbol.local != object_symbol.local {
+            if target_symbol.scope != object_symbol.scope {
                 log::info!(
                     "Changing symbol '{}' in {} at {:#010x} to {}",
                     target_symbol.name,
                     module_kind,
                     target_symbol.addr,
-                    if object_symbol.local { "local" } else { "global" }
+                    target_symbol.scope,
                 );
                 changed = true;
             }
             if !name_matches {
                 target_symbol.name = object_symbol.name.clone();
             }
-            target_symbol.local = object_symbol.local;
+            target_symbol.scope = object_symbol.scope;
             if changed {
                 num_changes += 1;
             }

--- a/cli/src/cmd/check/symbols.rs
+++ b/cli/src/cmd/check/symbols.rs
@@ -142,7 +142,7 @@ impl CheckSymbols {
 
             // The object crate always interprets labels as local for some reason
             if !is_label {
-                if matching_symbol.local && !target_symbol.local {
+                if matching_symbol.scope.is_local() && !target_symbol.scope.is_local() {
                     num_mismatches += 1;
                     log::error!(
                         "Symbol '{}' at {:#010x} in {} is expected to be global but is local",
@@ -152,7 +152,7 @@ impl CheckSymbols {
                     );
                     continue;
                 }
-                if !matching_symbol.local && target_symbol.local {
+                if !matching_symbol.scope.is_local() && target_symbol.scope.is_local() {
                     num_mismatches += 1;
                     log::error!(
                         "Symbol '{}' at {:#010x} in {} is expected to be local but is global",
@@ -162,6 +162,27 @@ impl CheckSymbols {
                     );
                     continue;
                 }
+            }
+
+            if matching_symbol.scope.is_weak() && !target_symbol.scope.is_weak() {
+                num_mismatches += 1;
+                log::error!(
+                    "Symbol '{}' at {:#010x} in {} is expected to be weak but is non-weak",
+                    target_symbol.name,
+                    target_symbol.addr,
+                    module_kind
+                );
+                continue;
+            }
+            if !matching_symbol.scope.is_weak() && target_symbol.scope.is_weak() {
+                num_mismatches += 1;
+                log::error!(
+                    "Symbol '{}' at {:#010x} in {} is expected to be non-weak but is weak",
+                    target_symbol.name,
+                    target_symbol.addr,
+                    module_kind
+                );
+                continue;
             }
         }
 

--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -25,7 +25,7 @@ use crate::{
         program::Program,
         relocation::{RelocationKindExt, RelocationModuleExt},
         section::SectionExt,
-        symbol::{SymbolExt, SymbolKindExt},
+        symbol::SymbolExt,
     },
     util::io::{create_dir_all, create_file},
 };
@@ -280,9 +280,9 @@ impl<'a> DelinkObject<'a> {
         while let Some((_, symbol)) = symbols.next() {
             // Get symbol data
             let max_address = symbols.peek().map_or(file_section.end_address(), |(_, s)| s.addr);
-            let kind = symbol.kind.as_obj_symbol_kind();
             let scope = symbol.get_obj_symbol_scope();
             let value = u64::from(symbol.addr - file_section.start_address());
+            let flags = symbol.get_obj_symbol_flags();
 
             // Create symbol
             let symbol_section = object::write::SymbolSection::Section(obj_section_id);
@@ -290,11 +290,11 @@ impl<'a> DelinkObject<'a> {
                 name: symbol.name.clone().into_bytes(),
                 value,
                 size: symbol.size(max_address).into(),
-                kind,
+                kind: object::SymbolKind::Unknown, // doesn't matter, overriden by `flags.st_info`
                 scope,
-                weak: false,
+                weak: false, // overriden by `flags.st_info`
                 section: symbol_section,
-                flags: object::SymbolFlags::None,
+                flags,
             });
 
             let is_thumb = matches!(
@@ -400,7 +400,7 @@ impl<'a> DelinkObject<'a> {
                             continue;
                         };
 
-                        if symbol.local {
+                        if symbol.scope.is_local() {
                             let (reloc_base, offset) = relocation
                                 .find_symbol_location(symbol_map)
                                 .map_or(("<unknown>", 0), |(symbol, offset)| {

--- a/cli/src/cmd/diff/apply.rs
+++ b/cli/src/cmd/diff/apply.rs
@@ -1048,7 +1048,7 @@ impl NewSymbol {
             kind: self.kind.clone(),
             addr: self.addr.0,
             ambiguous: self.ambiguous,
-            local: self.local,
+            scope: self.scope,
             skip: false,
             comments: Default::default(),
         }
@@ -1062,7 +1062,7 @@ impl SymbolDiff {
             kind: self.kind.before().clone(),
             addr: self.addr.0,
             ambiguous: *self.ambiguous.before(),
-            local: *self.local.before(),
+            scope: *self.scope.before(),
             skip: false,
             comments: Default::default(),
         }
@@ -1074,7 +1074,7 @@ impl SymbolDiff {
             kind: self.kind.after().clone(),
             addr: self.addr.0,
             ambiguous: *self.ambiguous.after(),
-            local: *self.local.after(),
+            scope: *self.scope.after(),
             skip: false,
             comments: Default::default(),
         }

--- a/cli/src/cmd/diff/mod.rs
+++ b/cli/src/cmd/diff/mod.rs
@@ -15,7 +15,7 @@ use ds_decomp::config::{
     module::ModuleKind,
     relocations::{RelocationKind, RelocationModule},
     section::SectionKind,
-    symbol::SymbolKind,
+    symbol::{SymbolKind, SymbolScope},
 };
 use new::*;
 use serde::{Deserialize, Serialize};
@@ -149,8 +149,8 @@ pub(crate) struct NewSymbol {
     pub(crate) addr: Hex<u32>,
     #[serde(skip_serializing_if = "is_false", default)]
     pub(crate) ambiguous: bool,
-    #[serde(skip_serializing_if = "is_false", default)]
-    pub(crate) local: bool,
+    #[serde(skip_serializing_if = "SymbolScope::is_global", default)]
+    pub(crate) scope: SymbolScope,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -159,7 +159,7 @@ pub(crate) struct SymbolDiff {
     pub(crate) kind: Diff<SymbolKind>,
     pub(crate) addr: Hex<u32>,
     pub(crate) ambiguous: Diff<bool>,
-    pub(crate) local: Diff<bool>,
+    pub(crate) scope: Diff<SymbolScope>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/cli/src/cmd/diff/new.rs
+++ b/cli/src/cmd/diff/new.rs
@@ -621,7 +621,7 @@ impl NewSymbol {
                 kind: symbol.kind.clone(),
                 addr: Hex(symbol.addr),
                 ambiguous: symbol.ambiguous,
-                local: symbol.local,
+                scope: symbol.scope,
             })
         } else {
             None
@@ -667,15 +667,15 @@ impl SymbolDiff {
         } else {
             Diff::new(before.ambiguous, after.ambiguous)
         };
-        let local = if cmd.skip_globalized_symbols && !after.local {
-            Diff::Equal(before.local)
+        let scope = if cmd.skip_globalized_symbols && after.scope.is_global() {
+            Diff::Equal(before.scope)
         } else {
-            Diff::new(before.local, after.local)
+            Diff::new(before.scope, after.scope)
         };
-        if name.is_equal() && kind.is_equal() && ambiguous.is_equal() && local.is_equal() {
+        if name.is_equal() && kind.is_equal() && ambiguous.is_equal() && scope.is_equal() {
             None
         } else {
-            Some(Self { name, kind, addr: Hex(before.addr), ambiguous, local })
+            Some(Self { name, kind, addr: Hex(before.addr), ambiguous, scope })
         }
     }
 }

--- a/cli/src/config/symbol.rs
+++ b/cli/src/config/symbol.rs
@@ -9,15 +9,20 @@ use ds_decomp::{
         relocations::Relocations,
         symbol::{
             InstructionMode, SymData, SymFunction, SymLabel, Symbol, SymbolKind, SymbolMap,
-            SymbolMaps,
+            SymbolMaps, SymbolScope,
         },
     },
 };
-use object::{Object, ObjectSection, ObjectSymbol};
+use object::{
+    Object, ObjectSection, ObjectSymbol,
+    elf::{self, STV_DEFAULT},
+};
 use unarm::LookupSymbol;
 
 use super::relocation::RelocationModuleExt;
 use crate::{config::module::ModuleKindExt, util::bytes::FromSlice};
+
+const STB_MWARM_WEAK: u8 = 14;
 
 pub struct LookupSymbolMap(SymbolMap);
 
@@ -72,13 +77,29 @@ impl SymbolMapsExt for SymbolMaps {
                 continue;
             };
 
+            let weak = match symbol.flags() {
+                object::SymbolFlags::Elf { st_info, st_other: _ } => {
+                    let st_bind = st_info >> 4;
+                    st_bind == STB_MWARM_WEAK
+                }
+                _ => false,
+            };
+
+            let scope = if weak {
+                SymbolScope::Weak
+            } else if symbol.is_local() {
+                SymbolScope::Local
+            } else {
+                SymbolScope::Global
+            };
+
             let symbol_map = symbol_maps.get_mut(module_kind);
             symbol_map.add(Symbol {
                 name: name.to_string(),
                 kind: SymbolKind::Undefined,
                 addr: symbol.address() as u32,
                 ambiguous: false,
-                local: symbol.is_local(),
+                scope,
                 skip: false,
                 comments: Comments::new(),
             });
@@ -94,6 +115,9 @@ pub trait SymbolExt {
     fn mapping_symbol_name(&self) -> Option<&str>;
 
     fn get_obj_symbol_scope(&self) -> object::SymbolScope;
+    fn get_obj_symbol_flags(
+        &self,
+    ) -> object::SymbolFlags<object::write::SectionId, object::write::SymbolId>;
 }
 
 impl SymbolExt for Symbol {
@@ -116,29 +140,32 @@ impl SymbolExt for Symbol {
     }
 
     fn get_obj_symbol_scope(&self) -> object::SymbolScope {
-        if self.local {
-            object::SymbolScope::Compilation
-        } else {
-            object::SymbolScope::Dynamic
+        match self.scope {
+            SymbolScope::Global | SymbolScope::Weak => object::SymbolScope::Dynamic,
+            SymbolScope::Local => object::SymbolScope::Compilation,
         }
     }
-}
 
-pub trait SymbolKindExt {
-    fn as_obj_symbol_kind(&self) -> object::SymbolKind;
-}
-
-impl SymbolKindExt for SymbolKind {
-    fn as_obj_symbol_kind(&self) -> object::SymbolKind {
-        match self {
-            Self::Undefined => object::SymbolKind::Unknown,
-            Self::Function(_) => object::SymbolKind::Text,
-            Self::Label { .. } => object::SymbolKind::Label,
-            Self::PoolConstant => object::SymbolKind::Data,
-            Self::JumpTable(_) => object::SymbolKind::Label,
-            Self::Data(_) => object::SymbolKind::Data,
-            Self::Bss(_) => object::SymbolKind::Data,
-        }
+    fn get_obj_symbol_flags(
+        &self,
+    ) -> object::SymbolFlags<object::write::SectionId, object::write::SymbolId> {
+        let st_type = match self.kind {
+            SymbolKind::Function(_) => elf::STT_FUNC,
+            SymbolKind::PoolConstant | SymbolKind::Label { .. } | SymbolKind::JumpTable(_) => {
+                elf::STT_NOTYPE
+            }
+            SymbolKind::Data(_) | SymbolKind::Bss(_) => elf::STT_OBJECT,
+            SymbolKind::Undefined => {
+                return object::SymbolFlags::None;
+            }
+        };
+        let st_bind = match self.scope {
+            SymbolScope::Global => elf::STB_GLOBAL,
+            SymbolScope::Local => elf::STB_LOCAL,
+            SymbolScope::Weak => STB_MWARM_WEAK,
+        };
+        let st_info = (st_bind << 4) | st_type;
+        object::SymbolFlags::Elf { st_info, st_other: STV_DEFAULT }
     }
 }
 

--- a/docs/symbols.md
+++ b/docs/symbols.md
@@ -74,16 +74,19 @@ data_02058e22 kind:bss addr:0x02058e22
 ### Symbol attributes
 - Local?: `local`
 - Ambiguous?: `ambiguous`
+- Weak?: `weak`
 
 A local symbol is only visible to its translation unit and will not cause a duplicate symbol definition error with the linker.
 
 Ambiguous symbols exist solely to resolve ambiguous relocations, where the relocation can lead to one of multiple overlays.
 
+A weak symbol is global but will be replaced by a non-weak symbol by the linker.
+
 Example:
 ```
 SameSymbolName kind:data(any) addr:0x02001234 local
 SameSymbolName kind:data(any) addr:0x02005678 local
-AmbiguousSymbol kind:bss addr:0x02009abc ambiguous
+WeakAmbiguousSymbol kind:bss addr:0x02009abc weak ambiguous
 ```
 
 ## Comments

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -42,7 +42,7 @@ use crate::{
         relocations::{
             Relocation, RelocationKind, RelocationModule, RelocationOptions, RelocationsError,
         },
-        symbol::{SymBss, Symbol},
+        symbol::{SymBss, Symbol, SymbolScope},
     },
     function,
 };
@@ -1188,7 +1188,7 @@ impl Module {
                     kind: SymbolKind::Bss(SymBss { size: None }),
                     addr: bss_variable,
                     ambiguous: false,
-                    local: false,
+                    scope: SymbolScope::Global,
                     skip: false,
                     comments: Comments::new(),
                 });

--- a/lib/src/config/symbol.rs
+++ b/lib/src/config/symbol.rs
@@ -842,9 +842,9 @@ pub struct Symbol {
     /// If true, this symbol is involved in an ambiguous external reference to one of many overlays
     #[serde(skip_serializing_if = "is_false", default)]
     pub ambiguous: bool,
-    /// If true, this symbol is local to its translation unit and will not cause duplicate symbol definitions in the linker
-    #[serde(skip_serializing_if = "is_false", default)]
-    pub local: bool,
+    /// The scope of this symbol: global, local, etc.
+    #[serde(skip_serializing_if = "SymbolScope::is_global", default)]
+    pub scope: SymbolScope,
     /// If true, this symbol will not be delinked or written to symbols.txt
     /// Used for symbols that are found during code analysis but whose size are accounted for by their function
     #[serde(skip, default)]
@@ -865,11 +865,13 @@ pub enum SymbolParseError {
         backtrace: Backtrace,
     },
     #[snafu(display(
-        "{context}: expected symbol attribute 'kind' or 'addr' but got '{key}':\n{backtrace}"
+        "{context}: unknown symbol attribute '{key}', expected 'kind', 'addr', 'ambiguous', 'local' or 'weak':\n{backtrace}"
     ))]
     UnknownAttribute { context: ParseContext, key: String, backtrace: Backtrace },
     #[snafu(display("{context}: missing '{attribute}' attribute:\n{backtrace}"))]
     MissingAttribute { context: ParseContext, attribute: String, backtrace: Backtrace },
+    #[snafu(display("{context}: the symbol cannot be both {old} and {new}:\n{backtrace}"))]
+    DoubleScope { context: ParseContext, old: SymbolScope, new: SymbolScope, backtrace: Backtrace },
 }
 
 impl Symbol {
@@ -883,7 +885,7 @@ impl Symbol {
         let mut kind = None;
         let mut addr = None;
         let mut ambiguous = false;
-        let mut local = false;
+        let mut scope = None;
         for (key, value) in split_attributes(words, ':') {
             match key {
                 "kind" => kind = Some(SymbolKind::parse(value, context)?),
@@ -894,7 +896,20 @@ impl Symbol {
                     )
                 }
                 "ambiguous" => ambiguous = true,
-                "local" => local = true,
+                "local" => {
+                    if let Some(scope) = scope {
+                        return DoubleScopeSnafu { context, old: scope, new: SymbolScope::Local }
+                            .fail();
+                    }
+                    scope = Some(SymbolScope::Local);
+                }
+                "weak" => {
+                    if let Some(scope) = scope {
+                        return DoubleScopeSnafu { context, old: scope, new: SymbolScope::Weak }
+                            .fail();
+                    }
+                    scope = Some(SymbolScope::Weak);
+                }
                 _ => return UnknownAttributeSnafu { context, key }.fail(),
             }
         }
@@ -904,13 +919,14 @@ impl Symbol {
             kind.ok_or_else(|| MissingAttributeSnafu { context, attribute: "kind" }.build())?;
         let addr =
             addr.ok_or_else(|| MissingAttributeSnafu { context, attribute: "addr" }.build())?;
+        let scope = scope.unwrap_or(SymbolScope::Global);
 
         Ok(Some(Symbol {
             name,
             kind,
             addr,
             ambiguous,
-            local,
+            scope,
             skip: false,
             comments: line.comments,
         }))
@@ -938,7 +954,7 @@ impl Symbol {
             }),
             addr: function.first_instruction_address() & !1,
             ambiguous: false,
-            local: false,
+            scope: SymbolScope::Global,
             skip: false,
             comments: Comments::new(),
         }
@@ -956,7 +972,7 @@ impl Symbol {
             }),
             addr,
             ambiguous: false,
-            local: false,
+            scope: SymbolScope::Global,
             skip: false,
             comments: Comments::new(),
         }
@@ -971,7 +987,7 @@ impl Symbol {
             }),
             addr,
             ambiguous: false,
-            local: true,
+            scope: SymbolScope::Local,
             skip: false,
             comments: Comments::new(),
         }
@@ -986,7 +1002,7 @@ impl Symbol {
             }),
             addr,
             ambiguous: false,
-            local: false,
+            scope: SymbolScope::Global,
             skip: false,
             comments: Comments::new(),
         }
@@ -998,7 +1014,7 @@ impl Symbol {
             kind: SymbolKind::PoolConstant,
             addr,
             ambiguous: false,
-            local: true,
+            scope: SymbolScope::Local,
             skip: false,
             comments: Comments::new(),
         }
@@ -1010,7 +1026,7 @@ impl Symbol {
             kind: SymbolKind::JumpTable(SymJumpTable { size, kind }),
             addr,
             ambiguous: false,
-            local: true,
+            scope: SymbolScope::Local,
             skip: false,
             comments: Comments::new(),
         }
@@ -1022,7 +1038,7 @@ impl Symbol {
             kind: SymbolKind::Data(data),
             addr,
             ambiguous,
-            local: false,
+            scope: SymbolScope::Global,
             skip: false,
             comments: Comments::new(),
         }
@@ -1034,7 +1050,7 @@ impl Symbol {
             kind: SymbolKind::Data(data),
             addr,
             ambiguous,
-            local: false,
+            scope: SymbolScope::Global,
             skip: true,
             comments: Comments::new(),
         }
@@ -1046,7 +1062,7 @@ impl Symbol {
             kind: SymbolKind::Bss(data),
             addr,
             ambiguous,
-            local: false,
+            scope: SymbolScope::Global,
             skip: false,
             comments: Comments::new(),
         }
@@ -1070,14 +1086,49 @@ impl Display for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.comments.display_pre_comments())?;
         write!(f, "{} kind:{} addr:{:#010x}", self.name, self.kind, self.addr)?;
-        if self.local {
-            write!(f, " local")?;
+        if !self.scope.is_global() {
+            write!(f, " {}", self.scope)?;
         }
         if self.ambiguous {
             write!(f, " ambiguous")?;
         }
         write!(f, "{}", self.comments.display_post_comment())?;
         Ok(())
+    }
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub enum SymbolScope {
+    /// The symbol is global and can be accessed from other translation units
+    #[default]
+    Global,
+    /// The symbol is local to its translation unit and will not cause duplicate symbol definitions in the linker
+    Local,
+    /// The symbol is weak and can be overriden by a non-weak symbol with the same name
+    Weak,
+}
+
+impl SymbolScope {
+    pub fn is_global(&self) -> bool {
+        *self == SymbolScope::Global
+    }
+
+    pub fn is_local(&self) -> bool {
+        *self == SymbolScope::Local
+    }
+
+    pub fn is_weak(&self) -> bool {
+        *self == SymbolScope::Weak
+    }
+}
+
+impl Display for SymbolScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SymbolScope::Global => write!(f, "global"),
+            SymbolScope::Local => write!(f, "local"),
+            SymbolScope::Weak => write!(f, "weak"),
+        }
     }
 }
 


### PR DESCRIPTION
Symbols can now be marked as `weak`, setting their `st_bind` to `STB_MWARM_WEAK = 14`. Highly unclear why the toolchain does not use `STB_WEAK`, but it just doesn't do that...

Since a symbol can't be local and weak at the same time, the `Symbol::local` field was replaced with `Symbol::scope` of type `SymbolScope`, which is an enum of `Global`, `Local` and `Weak`.

While I was messing with the ELF symbol flags, I also fixed an issue where pool constants were not diffable in asm-differ/decomp.me, see https://github.com/simonlindholm/asm-differ/issues/216. This was caused by pool constant label symbols being delinked as `STT_OBJECT` which objdump does not disassemble to a `.word` instruction. Now they delink as `STT_NOTYPE` instead.