### PR TITLE
`fix ov-sigs`: New subcommand for adding OverlaySignatures symbol

### DIFF
--- a/cli/src/cmd/fix/mod.rs
+++ b/cli/src/cmd/fix/mod.rs
@@ -1,12 +1,14 @@
 mod ctor_symbols;
 mod ctor_zero;
 mod dsprot;
+mod ov_sigs;
 mod thumb_nop;
 
 use clap::{Args, Subcommand};
 use ctor_symbols::*;
 use ctor_zero::*;
 use dsprot::*;
+use ov_sigs::*;
 use thumb_nop::*;
 
 /// Subcommands for retroactively fixing already initialized dsd projects.
@@ -23,6 +25,7 @@ impl FixArgs {
             FixCommands::CtorSymbols(ctor_symbols) => ctor_symbols.run(),
             FixCommands::CtorZero(ctor_zero) => ctor_zero.run(),
             FixCommands::Dsprot(dsprot) => dsprot.run(),
+            FixCommands::OvSigs(ov_sigs) => ov_sigs.run(),
         }
     }
 }
@@ -33,4 +36,5 @@ enum FixCommands {
     CtorSymbols(FixCtorSymbols),
     CtorZero(FixCtorZero),
     Dsprot(FixDsprot),
+    OvSigs(FixOvSigs),
 }

--- a/cli/src/cmd/fix/ov_sigs.rs
+++ b/cli/src/cmd/fix/ov_sigs.rs
@@ -1,0 +1,70 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Args;
+use ds_decomp::config::{
+    config::Config,
+    module::{ModuleKind, OVERLAY_SIGNATURES_SYMBOL_NAME},
+    symbol::{SymData, SymbolMapError, SymbolMaps},
+};
+
+/// Adds or renames the overlay signature table symbol.
+#[derive(Args, Clone)]
+pub struct FixOvSigs {
+    /// Path to config.yaml.
+    #[arg(long, short = 'c')]
+    config_path: PathBuf,
+
+    /// Dry run, do not write to any files.
+    #[arg(long, short = 'd')]
+    dry: bool,
+}
+
+impl FixOvSigs {
+    pub fn run(&self) -> Result<()> {
+        let config = Config::from_file(&self.config_path)?;
+        let config_path = self.config_path.parent().unwrap();
+
+        let mut symbol_maps = SymbolMaps::from_config(config_path, &config)?;
+
+        let rom = config.load_rom(config_path)?;
+
+        let arm9 = rom.arm9();
+        if arm9.overlay_signatures_offset() == 0 {
+            log::info!("This game has no overlay signature table, no changes will be made.");
+            return Ok(());
+        }
+
+        let overlay_signatures_address = arm9.base_address() + arm9.overlay_signatures_offset();
+        log::info!("Overlay signature table exists at {:#010x}", overlay_signatures_address);
+
+        let symbol_map = symbol_maps.get_mut(ModuleKind::Arm9);
+        match symbol_map
+            .rename_by_address(overlay_signatures_address, OVERLAY_SIGNATURES_SYMBOL_NAME)
+        {
+            Ok(renamed) => {
+                if !renamed {
+                    log::info!("OverlaySignatures symbol already exists, no changes will be made.");
+                    return Ok(());
+                }
+            }
+            Err(SymbolMapError::NoSymbolToRename { .. }) => {
+                symbol_map.add_data(
+                    Some(OVERLAY_SIGNATURES_SYMBOL_NAME.to_string()),
+                    overlay_signatures_address,
+                    SymData::Any,
+                )?;
+            }
+            Err(e) => Err(e)?,
+        };
+
+        if self.dry {
+            log::info!("Dry run, not writing changes to files.");
+            return Ok(());
+        }
+
+        symbol_maps.to_files(&config, config_path)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
As of #63 (specifically fbec672), the `Arm9BuildConfig` is constructed manually instead of basing it off the extracted `arm9.yaml` file. In that commit I discovered that dsd had been hard-copying the `overlay_signatures` offset from the base ROM the entire time, when it should be filling in the offset according to the actual location of the overlay signature table by looking for the `OverlaySignatures` symbol. That symbol was already created automatically by `dsd init`, but there wasn't a command for migrating old projects, which is what I added here.

