### PR TITLE
Options to delink/disassemble only one module

### DIFF
--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -40,6 +40,32 @@ pub struct Delink {
     /// Emit all mapping symbols, not just code-related ones.
     #[arg(long, short = 'M')]
     pub all_mapping_symbols: bool,
+
+    #[command(flatten)]
+    pub module_filter: ModuleFilterArgs,
+}
+
+#[derive(Args, Default)]
+pub struct ModuleFilterArgs {
+    /// Include main program and exclude unspecified modules.
+    #[arg(long)]
+    pub main: bool,
+
+    /// Include overlay(s) and exclude unspecified modules.
+    #[arg(long)]
+    pub overlay: Vec<u16>,
+
+    /// Include ITCM and exclude unspecified modules.
+    #[arg(long)]
+    pub itcm: bool,
+
+    /// Include DTCM and exclude unspecified modules.
+    #[arg(long)]
+    pub dtcm: bool,
+
+    /// Include autoload(s) and exclude unspecified modules.
+    #[arg(long)]
+    pub autoload: Vec<u32>,
 }
 
 struct Delinker<'a> {
@@ -57,6 +83,7 @@ impl Delink {
         let delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
             migrate_sections: true,
             generate_gap_files: true,
+            module_filter: self.module_filter.build(),
         })?;
 
         let rom = config.load_rom(config_path)?;
@@ -68,10 +95,58 @@ impl Delink {
             Delinker { rom, program, elf_path, all_mapping_symbols: self.all_mapping_symbols };
 
         for delinks in delinks_map.iter() {
-            delinker.delink_module(delinks)?;
+            // DelinksMap always loads autoload modules, skip delinking them if not specified
+            if self.module_filter.has(delinks.module_kind()) {
+                delinker.delink_module(delinks)?;
+            }
         }
 
         Ok(())
+    }
+}
+
+impl ModuleFilterArgs {
+    pub fn build(&self) -> Vec<ModuleKind> {
+        let mut module_filter = Vec::new();
+        if self.main {
+            module_filter.push(ModuleKind::Arm9);
+        }
+        module_filter.extend(self.overlay.iter().map(|&id| ModuleKind::Overlay(id)));
+        if self.itcm {
+            module_filter.push(ModuleKind::Autoload(AutoloadKind::Itcm));
+        }
+        if self.dtcm {
+            module_filter.push(ModuleKind::Autoload(AutoloadKind::Dtcm));
+        }
+        module_filter.extend(
+            self.autoload.iter().map(|&index| ModuleKind::Autoload(AutoloadKind::Unknown(index))),
+        );
+        module_filter
+    }
+
+    pub fn all() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.main
+            && self.overlay.is_empty()
+            && !self.itcm
+            && !self.dtcm
+            && self.autoload.is_empty()
+    }
+
+    pub fn has(&self, module: ModuleKind) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+        match module {
+            ModuleKind::Arm9 => self.main,
+            ModuleKind::Overlay(id) => self.overlay.contains(&id),
+            ModuleKind::Autoload(AutoloadKind::Itcm) => self.itcm,
+            ModuleKind::Autoload(AutoloadKind::Dtcm) => self.dtcm,
+            ModuleKind::Autoload(AutoloadKind::Unknown(index)) => self.autoload.contains(&index),
+        }
     }
 }
 

--- a/cli/src/cmd/diff/apply.rs
+++ b/cli/src/cmd/diff/apply.rs
@@ -411,6 +411,7 @@ fn apply_actions<'a>(
     let mut delinks_map = DelinksMap::from_config(config, config_path, DelinksMapOptions {
         migrate_sections: false,
         generate_gap_files: false,
+        module_filter: Vec::new(),
     })?;
     let mut symbol_maps = SymbolMaps::from_config(config_path, config)?;
     let mut relocations_map = RelocationsMap::from_config(config, config_path)?;

--- a/cli/src/cmd/diff/new.rs
+++ b/cli/src/cmd/diff/new.rs
@@ -130,8 +130,11 @@ struct ProjectInfo {
 
 impl ProjectInfo {
     fn new(config: &Config, config_path: &Path, rom: &Rom) -> Result<Self> {
-        let delinks_map_options =
-            DelinksMapOptions { migrate_sections: false, generate_gap_files: false };
+        let delinks_map_options = DelinksMapOptions {
+            migrate_sections: false,
+            generate_gap_files: false,
+            module_filter: Vec::new(),
+        };
         Ok(ProjectInfo {
             delinks_map: DelinksMap::from_config(config, config_path, delinks_map_options)?,
             program: Program::from_config(config_path, config, rom)?,

--- a/cli/src/cmd/dis.rs
+++ b/cli/src/cmd/dis.rs
@@ -17,6 +17,7 @@ use ds_rom::rom::Rom;
 
 use crate::{
     analysis::functions::FunctionExt,
+    cmd::ModuleFilterArgs,
     config::{
         delinks::{DelinksMap, DelinksMapOptions},
         symbol::{SymDataExt, SymbolLookup},
@@ -38,6 +39,9 @@ pub struct Disassemble {
     /// Disassemble with Unified Assembler Language (UAL) syntax.
     #[arg(long, short = 'u')]
     pub ual: bool,
+
+    #[command(flatten)]
+    pub module_filter: ModuleFilterArgs,
 }
 
 impl Disassemble {
@@ -51,13 +55,17 @@ impl Disassemble {
             // deleted by the other.
             migrate_sections: false,
             generate_gap_files: true,
+            module_filter: self.module_filter.build(),
         })?;
 
         let rom = config.load_rom(config_path)?;
 
         let mut symbol_maps = SymbolMaps::from_config(config_path, &config)?;
         for delinks in delinks_map.iter() {
-            self.disassemble_module(&config, delinks, &mut symbol_maps, &rom)?;
+            // DelinksMap always loads autoload modules, skip disassembling them if not specified
+            if self.module_filter.has(delinks.module_kind()) {
+                self.disassemble_module(&config, delinks, &mut symbol_maps, &rom)?;
+            }
         }
 
         Ok(())

--- a/cli/src/cmd/fix/ctor_zero.rs
+++ b/cli/src/cmd/fix/ctor_zero.rs
@@ -44,6 +44,7 @@ impl FixCtorZero {
         let mut delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
             migrate_sections: false,
             generate_gap_files: false,
+            module_filter: Vec::new(),
         })?;
         let mut symbol_maps = SymbolMaps::from_config(config_path, &config)?;
         let mut relocs_map = RelocationsMap::from_config(&config, config_path)?;

--- a/cli/src/cmd/json/delinks.rs
+++ b/cli/src/cmd/json/delinks.rs
@@ -53,6 +53,7 @@ impl JsonDelinks {
             // call `DelinksMap::delink_files()` later
             migrate_sections: false,
             generate_gap_files: true,
+            module_filter: Vec::new(),
         })?;
 
         let files = delinks_map

--- a/cli/src/cmd/lcf.rs
+++ b/cli/src/cmd/lcf.rs
@@ -104,6 +104,7 @@ impl Lcf {
             // We want migrated sections to be linked in the module it belongs to
             migrate_sections: true,
             generate_gap_files: true,
+            module_filter: Vec::new(),
         })?;
         Self::validate_all_file_names(&delinks_map)?;
 

--- a/cli/src/cmd/objdiff.rs
+++ b/cli/src/cmd/objdiff.rs
@@ -85,6 +85,7 @@ impl Objdiff {
             // unit.
             migrate_sections: false,
             generate_gap_files: true,
+            module_filter: Vec::new(),
         })?;
 
         let mut units = Vec::new();

--- a/cli/src/config/delinks.rs
+++ b/cli/src/config/delinks.rs
@@ -298,6 +298,9 @@ pub struct DelinksMap {
 pub struct DelinksMapOptions {
     pub migrate_sections: bool,
     pub generate_gap_files: bool,
+    /// If non-empty, only load these modules. Note that autoload modules will always be loaded so
+    /// that sections like .dtcm and .itcm may be migrated.
+    pub module_filter: Vec<ModuleKind>,
 }
 
 impl DelinksMap {
@@ -309,6 +312,11 @@ impl DelinksMap {
         let path = path.as_ref();
         let map = config
             .iter_modules()
+            .filter(|(kind, _)| {
+                options.module_filter.is_empty()
+                    || matches!(kind, ModuleKind::Autoload(_))
+                    || options.module_filter.contains(kind)
+            })
             .map(|(kind, config)| {
                 let delinks = Delinks::from_file(path.join(&config.delinks), kind)?;
                 Ok((kind, delinks))

--- a/cli/tests/test_roundtrip.rs
+++ b/cli/tests/test_roundtrip.rs
@@ -14,7 +14,10 @@ use ds_decomp::{
     config::{config::Config, module::ModuleError},
 };
 use ds_decomp_cli::{
-    cmd::{CheckModules, CheckSymbols, ConfigRom, Delink, Disassemble, Init, JsonDelinks, Lcf},
+    cmd::{
+        CheckModules, CheckSymbols, ConfigRom, Delink, Disassemble, Init, JsonDelinks, Lcf,
+        ModuleFilterArgs,
+    },
     util::io::{create_dir_all, read_to_string},
 };
 use ds_rom::{
@@ -110,6 +113,7 @@ fn test_roundtrip() -> Result<()> {
             config_path: dsd_config_yaml.clone(),
             asm_path: project_path.join("asm"),
             ual: false,
+            module_filter: ModuleFilterArgs::all(),
         };
         disassemble.run()?;
 
@@ -120,6 +124,7 @@ fn test_roundtrip() -> Result<()> {
             // Some games have functions outside .text and .init, which get placed in data sections by dsd. Setting this to
             // true ensures that they get marked as ARM/Thumb correctly and no veneers are generated for them.
             all_mapping_symbols: true,
+            module_filter: ModuleFilterArgs::all(),
         };
         delink.run()?;
 


### PR DESCRIPTION
This adds `--main`, `--overlay <id>`, `--itcm`, `--dtcm` and `--autoload <index>` to `dsd delink` and `dsd dis`. They are all optional, and specifying any of them will make dsd only delink or disassemble the specified modules. Not specifying any of them still delinks/disassembles all modules as before.

The purpose of this is the possibility of more granular build systems, which makes delinking faster for incremental builds and thus faster to iterate on `.txt` files.