### PR TITLE
Fix `Function::parse_function` parsing instruction mode from the wrong instruction

### DIFF
--- a/lib/src/analysis/ctor.rs
+++ b/lib/src/analysis/ctor.rs
@@ -63,7 +63,7 @@ impl CtorRange {
         let entry_code = &code[(entry_addr - arm9.base_address()) as usize..];
         let parse_result = Function::parse_function(FunctionParseOptions {
             name: "entry".to_string(),
-            start_address: arm9.entry_function(),
+            start_address: entry_addr,
             base_address: entry_addr,
             module_code: entry_code,
             known_end_address: None,

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -220,10 +220,11 @@ impl Function {
             start_address, base_address, module_code, parse_options, ..
         } = &options;
 
-        let thumb =
-            parse_options.thumb.unwrap_or(Function::is_thumb_function(*start_address, module_code));
-        let parse_mode = if thumb { ParseMode::Thumb } else { ParseMode::Arm };
         let start = (start_address - base_address) as usize;
+        let thumb = parse_options
+            .thumb
+            .unwrap_or(Function::is_thumb_function(*start_address, &module_code[start..]));
+        let parse_mode = if thumb { ParseMode::Thumb } else { ParseMode::Arm };
         let function_code = &module_code[start..];
         let parser =
             Parser::new(parse_mode, *start_address, Endian::Little, PARSE_FLAGS, function_code);

--- a/lib/src/analysis/main.rs
+++ b/lib/src/analysis/main.rs
@@ -92,7 +92,7 @@ impl MainFunction {
         let entry_code = &code[(entry_addr - arm9.base_address()) as usize..];
         let parse_result = Function::parse_function(FunctionParseOptions {
             name: "entry".to_string(),
-            start_address: arm9.entry_function(),
+            start_address: entry_addr,
             base_address: entry_addr,
             module_code: entry_code,
             known_end_address: None,


### PR DESCRIPTION
This really only applied to when `AutoloadCallback` is parsed during `dsd init`, as it was the only case where `base_address` and `start_address` weren't the same. In all other cases where they are the same, `&module_code[start..]` is a no-op.