### PR TITLE
delink/dis: Give relocation addend hint when symbol is missing

### DIFF
--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -471,6 +471,18 @@ impl<'a> DelinkObject<'a> {
                                 dest_addr,
                                 reloc_module
                             );
+                            if let Some(&(_, symbol)) = external_symbol_map
+                                .first_symbol_before(dest_addr)
+                                .unwrap_or_default()
+                                .first()
+                            {
+                                log::error!(
+                                    "Perhaps you want to reference the symbol {} with 'to:{:#010x} add:{:#x}' instead?",
+                                    symbol.name,
+                                    symbol.addr,
+                                    dest_addr - symbol.addr
+                                );
+                            }
                             error = true;
                             continue;
                         };

--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -480,7 +480,7 @@ impl<'a> DelinkObject<'a> {
                                     "Perhaps you want to reference the symbol {} with 'to:{:#010x} add:{:#x}' instead?",
                                     symbol.name,
                                     symbol.addr,
-                                    dest_addr - symbol.addr
+                                    i64::from(dest_addr - symbol.addr) + relocation.addend()
                                 );
                             }
                             error = true;

--- a/cli/src/config/symbol.rs
+++ b/cli/src/config/symbol.rs
@@ -309,6 +309,18 @@ impl SymbolLookup<'_> {
                         "Symbol not found for relocation from {source:#010x} in {} to {symbol_address:#010x} in {module_kind}",
                         self.module_kind
                     );
+                    if let Some(&(_, symbol)) = external_symbol_map
+                        .first_symbol_before(symbol_address)
+                        .unwrap_or_default()
+                        .first()
+                    {
+                        log::warn!(
+                            "Perhaps you want to reference the symbol {} with 'to:{:#010x} add:{:#x}' instead?",
+                            symbol.name,
+                            symbol.addr,
+                            i64::from(symbol_address - symbol.addr) + relocation.addend()
+                        );
+                    }
                     write!(w, "{symbol_address:#010x} ; ERROR: Symbol not found for relocation")?;
                 }
 


### PR DESCRIPTION
When `dsd delink` fails to create a relocation that points to a non-existent symbol, it will display a hint to change the relocation destination and addend.

Example:
```
[ERROR] No symbol found for relocation from 0x020b3114 in overlay 0 to 0x020984bc in overlay 0
[ERROR] Perhaps you want to reference the symbol _ZN5Actor8vfunc_24Ev with 'to:0x020984b8 add:0x4' instead?
```

A similar hint exists for `dsd dis` as well.