### PR TITLE
.exceptix link time constants; migrate exception data to ARM9 main

### DIFF
--- a/assets/arm9.lcf.template
+++ b/assets/arm9.lcf.template
@@ -14,7 +14,8 @@ MEMORY \{
 
 KEEP_SECTION \{
     .init,
-    .ctor
+    .ctor,
+    .exceptix
 }
 
 SECTIONS \{

--- a/assets/arm9.lcf.template
+++ b/assets/arm9.lcf.template
@@ -35,9 +35,8 @@ SECTIONS \{
         {{ for file in section.files -}}
         {file.name}({file.section_name})
         {{ endfor }}
-        {{ if section.append_zero -}}
-        WRITEW(0);
-        {{- endif }}
+        {{ if section.append_zero }}WRITEW(0);{{ endif }}
+        {{ if section.exceptix }}EXCEPTION{{ endif }}
         . = ALIGN({section.end_alignment});
         {section.end_symbol} = .;
         {{ endfor }}

--- a/cli/src/cmd/check/symbols.rs
+++ b/cli/src/cmd/check/symbols.rs
@@ -4,11 +4,18 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use ds_decomp::config::{
     config::Config,
+    delinks::Delinks,
     module::ModuleKind,
     symbol::{SymbolKind, SymbolMap, SymbolMaps},
 };
 
-use crate::{config::symbol::SymbolMapsExt, util::io::read_file};
+use crate::{
+    config::{
+        delinks::{DelinksMap, DelinksMapOptions},
+        symbol::SymbolMapsExt,
+    },
+    util::io::read_file,
+};
 
 /// Verifies that built modules are matching the base ROM.
 #[derive(Args)]
@@ -42,28 +49,42 @@ impl CheckSymbols {
         let mut success = true;
 
         let symbol_maps = SymbolMaps::from_config(config_path, &config)?;
+        let delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
+            migrate_sections: false,
+            generate_gap_files: false,
+            module_filter: Vec::new(),
+        })?;
         if let Some(target_symbols) = symbol_maps.get(ModuleKind::Arm9) {
+            let delinks = delinks_map
+                .get(ModuleKind::Arm9)
+                .context("Symbol map exists for ARM9 main but not delinks")?;
             let object_symbols = object_symbol_maps
                 .get(ModuleKind::Arm9)
                 .context("ARM9 symbols not found in linked binary")?;
-            success &= self.check_symbol_map(object_symbols, target_symbols, ModuleKind::Arm9);
+            success &= self.check_symbol_map(object_symbols, target_symbols, delinks);
         }
         for autoload in &config.autoloads {
             let module_kind = ModuleKind::Autoload(autoload.kind);
             if let Some(target_symbols) = symbol_maps.get(module_kind) {
+                let delinks = delinks_map.get(module_kind).with_context(|| {
+                    format!("Symbol map exists for {module_kind} but not delinks")
+                })?;
                 let object_symbols = object_symbol_maps.get(module_kind).with_context(|| {
                     format!("Symbols for {module_kind} not found in linked binary")
                 })?;
-                success &= self.check_symbol_map(object_symbols, target_symbols, module_kind);
+                success &= self.check_symbol_map(object_symbols, target_symbols, delinks);
             }
         }
         for overlay in &config.overlays {
             let module_kind = ModuleKind::Overlay(overlay.id);
             if let Some(target_symbols) = symbol_maps.get(module_kind) {
+                let delinks = delinks_map.get(module_kind).with_context(|| {
+                    format!("Symbol map exists for {module_kind} but not delinks")
+                })?;
                 let object_symbols = object_symbol_maps.get(module_kind).with_context(|| {
                     format!("Symbols for {module_kind} not found in linked binary")
                 })?;
-                success &= self.check_symbol_map(object_symbols, target_symbols, module_kind);
+                success &= self.check_symbol_map(object_symbols, target_symbols, delinks);
             }
         }
 
@@ -74,12 +95,9 @@ impl CheckSymbols {
         Ok(())
     }
 
-    fn check_symbol_map(
-        &self,
-        object: &SymbolMap,
-        target: &SymbolMap,
-        module_kind: ModuleKind,
-    ) -> bool {
+    fn check_symbol_map(&self, object: &SymbolMap, target: &SymbolMap, delinks: &Delinks) -> bool {
+        let module_kind = delinks.module_kind();
+
         let mut num_mismatches = 0;
 
         for target_symbol in target.iter() {
@@ -90,6 +108,13 @@ impl CheckSymbols {
 
             if matches!(target_symbol.kind, SymbolKind::Label(_)) {
                 // Label symbols are not imported by SymbolMapsExt::from_object
+                continue;
+            }
+            if let Some((_, section)) =
+                delinks.sections.get_by_contained_address(target_symbol.addr)
+                && section.name() == ".exceptix"
+            {
+                // Exception table index symbols are stripped by the EXCEPTION command in the LCF
                 continue;
             }
 

--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -163,28 +163,25 @@ impl<'a> Delinker<'a> {
             for section in file.sections.iter() {
                 let module = self.program.by_module_kind(delinks.module_kind()).unwrap();
                 let (symbol_map, section_end) = if let Some(migrate_section) =
-                    MigrateSection::parse(section.name())?
+                    MigrateSection::parse(section.name(), delinks.module_kind())?
                 {
-                    let autoload_kind = match migrate_section {
-                        MigrateSection::Dtcm => AutoloadKind::Dtcm,
-                        MigrateSection::Itcm => AutoloadKind::Itcm,
-                        MigrateSection::AutoloadData(index)
-                        | MigrateSection::AutoloadBss(index) => AutoloadKind::Unknown(index),
+                    let section_end = match migrate_section.module_kind() {
+                        ModuleKind::Arm9 => self.rom.arm9().end_address()?,
+                        ModuleKind::Overlay(id) => {
+                            self.rom.arm7_overlays()[id as usize].end_address()
+                        }
+                        ModuleKind::Autoload(autoload_kind) => self
+                            .rom
+                            .arm9()
+                            .autoloads()?
+                            .iter()
+                            .find_map(|a| (a.kind() == autoload_kind).then_some(a.end_address()))
+                            .context("Failed to find end address of autoload")?,
                     };
-                    let autoload_end = self
-                        .rom
-                        .arm9()
-                        .autoloads()?
-                        .iter()
-                        .find_map(|a| (a.kind() == autoload_kind).then_some(a.end_address()))
-                        .context("Failed to find end address of DTCM autoload")?;
-                    (
-                        self.program
-                            .symbol_maps()
-                            .get(ModuleKind::Autoload(autoload_kind))
-                            .unwrap(),
-                        autoload_end,
-                    )
+
+                    let symbol_map =
+                        self.program.symbol_maps().get(migrate_section.module_kind()).unwrap();
+                    (symbol_map, section_end)
                 } else {
                     let (_, module_section) = module.sections().by_name(section.name()).unwrap();
                     (symbol_map, module_section.end_address())
@@ -251,20 +248,20 @@ impl<'a> Delinker<'a> {
                 // delinked from the source module
                 continue;
             }
-            delink_object.define_section(file_section, self.all_mapping_symbols)?;
+            delink_object.define_section(file_section, module_kind, self.all_mapping_symbols)?;
         }
         for file_section in delink_file.migrated_sections.iter() {
-            delink_object.define_section(file_section, self.all_mapping_symbols)?;
+            delink_object.define_section(file_section, module_kind, self.all_mapping_symbols)?;
         }
 
         let mut error = false;
 
         // Must start a new loop here so we can know which section a symbol ID belongs to
         for file_section in delink_file.sections.iter() {
-            error |= delink_object.define_relocations(file_section)?;
+            error |= delink_object.define_relocations(file_section, module_kind)?;
         }
         for file_section in delink_file.migrated_sections.iter() {
-            error |= delink_object.define_relocations(file_section)?;
+            error |= delink_object.define_relocations(file_section, module_kind)?;
         }
         if error {
             bail!("Failed to delink '{}', see errors above", delink_file.name);
@@ -308,13 +305,15 @@ impl<'a> DelinkObject<'a> {
     fn define_section(
         &mut self,
         file_section: &Section,
+        src_module: ModuleKind,
         all_mapping_symbols: bool,
     ) -> Result<(), anyhow::Error> {
-        let symbol_module = if let Some(migration) = MigrateSection::parse(file_section.name())? {
-            migration.module_kind()
-        } else {
-            self.current_module
-        };
+        let symbol_module =
+            if let Some(migration) = MigrateSection::parse(file_section.name(), src_module)? {
+                migration.module_kind()
+            } else {
+                self.current_module
+            };
         let module = self.program.by_module_kind(symbol_module).unwrap();
 
         let code = file_section
@@ -404,7 +403,11 @@ impl<'a> DelinkObject<'a> {
         Ok(())
     }
 
-    fn define_relocations(&mut self, file_section: &Section) -> Result<bool, anyhow::Error> {
+    fn define_relocations(
+        &mut self,
+        file_section: &Section,
+        src_module: ModuleKind,
+    ) -> Result<bool, anyhow::Error> {
         let symbol_map = self.program.symbol_maps().get(self.current_module).unwrap();
 
         let mut error = false;
@@ -420,7 +423,7 @@ impl<'a> DelinkObject<'a> {
                 )
             })
             .unwrap();
-        let module_kind = MigrateSection::parse(file_section.name())?
+        let module_kind = MigrateSection::parse(file_section.name(), src_module)?
             .map_or(self.current_module, |m| m.module_kind());
         let module = self.program.by_module_kind(module_kind).unwrap();
         for (_, relocation) in module.relocations().iter_range(file_section.address_range()) {

--- a/cli/src/cmd/fix/find_exceptix.rs
+++ b/cli/src/cmd/fix/find_exceptix.rs
@@ -3,10 +3,11 @@ use std::path::PathBuf;
 use anyhow::{Context as _, Result, bail};
 use clap::Args;
 use ds_decomp::{
-    analysis::exception::ExceptionData,
+    analysis::exception::{ExceptionData, ExceptionTableEntry},
     config::{
         config::Config,
         module::{FIND_EXCEPTION_TABLE_SYMBOL_NAME, ModuleKind},
+        symbol::SymData,
     },
 };
 use ds_rom::rom::raw::AutoloadKind;
@@ -65,6 +66,8 @@ impl FindExceptix {
             );
         }
 
+        self.add_exception_table_symbols(&mut program, exception_data)?;
+
         if self.dry {
             log::info!("Dry run, not writing changes to files.");
             return Ok(());
@@ -97,5 +100,60 @@ impl FindExceptix {
         } else {
             Ok(false)
         }
+    }
+
+    fn add_exception_table_symbols(
+        &self,
+        program: &mut Program,
+        exception_data: ExceptionData<'_>,
+    ) -> Result<(), anyhow::Error> {
+        let symbol_map = program.symbol_maps_mut().get_mut(ModuleKind::Arm9);
+        let mut ex_symbols = 0;
+        let mut et_symbols = 0;
+        for (i, entry) in exception_data.exception_table.iter().enumerate() {
+            let address = exception_data.exceptix_start
+                + (i * std::mem::size_of::<ExceptionTableEntry>()) as u32;
+
+            if let Some((id, symbol)) = symbol_map.by_address(address)? {
+                if !symbol.name.starts_with("@EX@") {
+                    symbol_map.remove(id);
+                    symbol_map.add_data(
+                        Some(format!("@EX@{:08x}", entry.function_address)),
+                        address,
+                        SymData::Word { count: Some(3) },
+                    )?;
+                }
+            } else {
+                symbol_map.add_data(
+                    Some(format!("@EX@{:08x}", entry.function_address)),
+                    address,
+                    SymData::Word { count: Some(3) },
+                )?;
+            }
+            ex_symbols += 1;
+
+            if (entry.function_length & 1) == 0 {
+                if let Some((id, symbol)) = symbol_map.by_address(entry.exception_record)? {
+                    if !symbol.name.starts_with("@ET@") {
+                        symbol_map.remove(id);
+                        symbol_map.add_data(
+                            Some(format!("@ET@{:08x}", entry.function_address)),
+                            entry.exception_record,
+                            SymData::Any,
+                        )?;
+                    }
+                } else {
+                    symbol_map.add_data(
+                        Some(format!("@ET@{:08x}", entry.function_address)),
+                        entry.exception_record,
+                        SymData::Any,
+                    )?;
+                }
+                et_symbols += 1;
+            }
+        }
+        log::info!("Found {ex_symbols} exception table records in .exception");
+        log::info!("Found {et_symbols} exception table entries in .exceptix");
+        Ok(())
     }
 }

--- a/cli/src/cmd/fix/find_exceptix.rs
+++ b/cli/src/cmd/fix/find_exceptix.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+
+use anyhow::{Context as _, Result, bail};
+use clap::Args;
+use ds_decomp::{
+    analysis::exception::ExceptionData,
+    config::{
+        config::Config,
+        module::{FIND_EXCEPTION_TABLE_SYMBOL_NAME, ModuleKind},
+    },
+};
+use ds_rom::rom::raw::AutoloadKind;
+
+use crate::config::program::Program;
+
+/// Locates link-time constants __exception_table_start/end__.
+#[derive(Args, Clone)]
+pub struct FindExceptix {
+    /// Path to config.yaml.
+    #[arg(long, short = 'c')]
+    config_path: PathBuf,
+
+    /// Dry run, do not write to any files.
+    #[arg(long, short = 'd')]
+    dry: bool,
+}
+
+impl FindExceptix {
+    pub fn run(&self) -> Result<()> {
+        let config = Config::from_file(&self.config_path)?;
+        let config_path = self.config_path.parent().unwrap();
+
+        let rom = config.load_rom(config_path)?;
+
+        let mut program = Program::from_config(config_path, &config, &rom)?;
+
+        let autoloads = rom.arm9().autoloads()?;
+        let unknown_autoloads = autoloads
+            .iter()
+            .filter(|a| !matches!(a.kind(), AutoloadKind::Unknown(_)))
+            .collect::<Vec<_>>();
+        let Some(exception_data) = ExceptionData::analyze(rom.arm9(), &unknown_autoloads)? else {
+            log::info!("{FIND_EXCEPTION_TABLE_SYMBOL_NAME} not found, no changes will be made");
+            return Ok(());
+        };
+
+        let mut found = false;
+        if self.fix_module(&mut program, ModuleKind::Arm9, &exception_data)? {
+            found = true;
+        } else {
+            for autoload in unknown_autoloads {
+                if self.fix_module(
+                    &mut program,
+                    ModuleKind::Autoload(autoload.kind()),
+                    &exception_data,
+                )? {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if !found {
+            bail!(
+                "{FIND_EXCEPTION_TABLE_SYMBOL_NAME} found but it did not belong to ARM9 main or custom autoloads?"
+            );
+        }
+
+        if self.dry {
+            log::info!("Dry run, not writing changes to files.");
+            return Ok(());
+        }
+
+        program.write_to_files(config_path, &config)?;
+
+        Ok(())
+    }
+
+    fn fix_module(
+        &self,
+        program: &mut Program,
+        module_kind: ModuleKind,
+        exception_data: &ExceptionData,
+    ) -> Result<bool> {
+        let (symbol_map, module) = program
+            .symbol_map_and_module_mut(module_kind)
+            .with_context(|| format!("Module not found: {module_kind}"))?;
+        let function = module.analyze_find_exception_table_fn(
+            exception_data.find_exception_table_fn_addr,
+            exception_data.find_exception_table_fn,
+            symbol_map,
+        )?;
+        if function.is_some() {
+            log::info!(
+                "{FIND_EXCEPTION_TABLE_SYMBOL_NAME} found in {module_kind}, adding link-time constant relocations"
+            );
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/cli/src/cmd/fix/mod.rs
+++ b/cli/src/cmd/fix/mod.rs
@@ -1,6 +1,7 @@
 mod ctor_symbols;
 mod ctor_zero;
 mod dsprot;
+mod find_exceptix;
 mod ov_sigs;
 mod thumb_nop;
 
@@ -8,6 +9,7 @@ use clap::{Args, Subcommand};
 use ctor_symbols::*;
 use ctor_zero::*;
 use dsprot::*;
+use find_exceptix::*;
 use ov_sigs::*;
 use thumb_nop::*;
 
@@ -26,6 +28,7 @@ impl FixArgs {
             FixCommands::CtorZero(ctor_zero) => ctor_zero.run(),
             FixCommands::Dsprot(dsprot) => dsprot.run(),
             FixCommands::OvSigs(ov_sigs) => ov_sigs.run(),
+            FixCommands::FindExceptix(find_exceptix) => find_exceptix.run(),
         }
     }
 }
@@ -37,4 +40,5 @@ enum FixCommands {
     CtorZero(FixCtorZero),
     Dsprot(FixDsprot),
     OvSigs(FixOvSigs),
+    FindExceptix(FindExceptix),
 }

--- a/cli/src/cmd/lcf.rs
+++ b/cli/src/cmd/lcf.rs
@@ -60,6 +60,7 @@ struct LcfSection {
     start_symbol: String,
     end_symbol: String,
     append_zero: bool,
+    exceptix: bool,
     files: Vec<LcfFile>,
 }
 
@@ -149,6 +150,8 @@ impl Lcf {
                     LinkTimeConst::CodeHi => "ADDR(SPACE)".to_string(),
                     LinkTimeConst::OverlayCount => overlay_count.to_string(),
                     LinkTimeConst::Arm9CtorStart => return None, // ARM9_CTOR_START already exists
+                    LinkTimeConst::ExceptionTableStart => return None, // __exception_table_start__
+                    LinkTimeConst::ExceptionTableEnd => return None, // __exception_table_end__
                 };
                 Some(LcfVariable::new(var.to_string(), value))
             })
@@ -290,26 +293,38 @@ impl LcfModule {
                 let name = section.name().to_string();
                 let alignment = section.alignment();
                 let append_zero = section.name() == ".ctor";
+                let exceptix = section.name() == ".exceptix";
                 let end_address = section.end_address() + if append_zero { 4 } else { 0 };
                 let end_alignment = if end_address % 32 == 0 { 32 } else { 4 };
-                let boundary_name = section.boundary_name();
-                let start_symbol = format!("{module_name}_{boundary_name}_START");
-                let end_symbol = format!("{module_name}_{boundary_name}_END");
-                let files = delinks
-                    .files
-                    .iter()
-                    .filter_map(|file| {
-                        file.sections
-                            .by_name(&name)
-                            .map(|(_, section)| (file, section.source_name().to_string()))
-                    })
-                    .map(|(file, section_name)| {
-                        let (file, _) = file.split_file_ext();
-                        let name =
-                            file.rsplit_once(['/', '\\']).map_or(file, |(_, basefile)| basefile);
-                        LcfFile { name: format!("{name}.o"), section_name }
-                    })
-                    .collect::<Vec<_>>();
+                let (start_symbol, end_symbol) = if exceptix {
+                    ("__exception_table_start__".to_string(), "__exception_table_end__".to_string())
+                } else {
+                    let boundary_name = section.boundary_name();
+                    (
+                        format!("{module_name}_{boundary_name}_START"),
+                        format!("{module_name}_{boundary_name}_END"),
+                    )
+                };
+                let files = if exceptix {
+                    Vec::new()
+                } else {
+                    delinks
+                        .files
+                        .iter()
+                        .filter_map(|file| {
+                            file.sections
+                                .by_name(&name)
+                                .map(|(_, section)| (file, section.source_name().to_string()))
+                        })
+                        .map(|(file, section_name)| {
+                            let (file, _) = file.split_file_ext();
+                            let name = file
+                                .rsplit_once(['/', '\\'])
+                                .map_or(file, |(_, basefile)| basefile);
+                            LcfFile { name: format!("{name}.o"), section_name }
+                        })
+                        .collect::<Vec<_>>()
+                };
                 LcfSection {
                     name,
                     alignment,
@@ -317,6 +332,7 @@ impl LcfModule {
                     start_symbol,
                     end_symbol,
                     append_zero,
+                    exceptix,
                     files,
                 }
             })

--- a/cli/src/config/delinks.rs
+++ b/cli/src/config/delinks.rs
@@ -298,8 +298,8 @@ pub struct DelinksMap {
 pub struct DelinksMapOptions {
     pub migrate_sections: bool,
     pub generate_gap_files: bool,
-    /// If non-empty, only load these modules. Note that autoload modules will always be loaded so
-    /// that sections like .dtcm and .itcm may be migrated.
+    /// If non-empty, only load these modules. Note that ARM9 main and autoload modules will always
+    /// be loaded so that sections like .dtcm, .itcm and .exception may be migrated.
     pub module_filter: Vec<ModuleKind>,
 }
 
@@ -314,7 +314,7 @@ impl DelinksMap {
             .iter_modules()
             .filter(|(kind, _)| {
                 options.module_filter.is_empty()
-                    || matches!(kind, ModuleKind::Autoload(_))
+                    || matches!(kind, ModuleKind::Arm9 | ModuleKind::Autoload(_))
                     || options.module_filter.contains(kind)
             })
             .map(|(kind, config)| {

--- a/cli/src/config/program.rs
+++ b/cli/src/config/program.rs
@@ -5,7 +5,7 @@ use ds_decomp::config::{
     config::Config,
     module::{AnalysisOptions, Module, ModuleKind},
     section::SectionKind,
-    symbol::{SymBss, SymData, SymbolMaps},
+    symbol::{SymBss, SymData, SymbolMap, SymbolMaps},
 };
 use ds_rom::rom::Rom;
 
@@ -120,8 +120,11 @@ impl Program {
                                 symbol_map.add_data(Some(name), symbol.address, SymData::Any)?;
                             }
                             SectionKind::Bss => {
-                                symbol_map
-                                    .add_bss(Some(name), symbol.address, SymBss { size: None })?;
+                                symbol_map.add_bss(
+                                    Some(name),
+                                    symbol.address,
+                                    SymBss { size: None },
+                                )?;
                             }
                         }
                     }
@@ -206,6 +209,18 @@ impl Program {
 
     pub fn symbol_maps_mut(&mut self) -> &mut SymbolMaps {
         &mut self.symbol_maps
+    }
+
+    pub fn symbol_map_and_module_mut(
+        &mut self,
+        module_kind: ModuleKind,
+    ) -> Option<(&mut SymbolMap, &mut Module)> {
+        if let Some(module) = self.modules.iter_mut().find(|m| m.kind() == module_kind) {
+            let symbol_map = self.symbol_maps.get_mut(module_kind);
+            Some((symbol_map, module))
+        } else {
+            None
+        }
     }
 
     /// Writes the symbols.txt and relocs.txt files for each module in the program.

--- a/cli/src/config/program.rs
+++ b/cli/src/config/program.rs
@@ -120,11 +120,8 @@ impl Program {
                                 symbol_map.add_data(Some(name), symbol.address, SymData::Any)?;
                             }
                             SectionKind::Bss => {
-                                symbol_map.add_bss(
-                                    Some(name),
-                                    symbol.address,
-                                    SymBss { size: None },
-                                )?;
+                                symbol_map
+                                    .add_bss(Some(name), symbol.address, SymBss { size: None })?;
                             }
                         }
                     }

--- a/docs/relocs.md
+++ b/docs/relocs.md
@@ -29,7 +29,7 @@ from:FROM kind:KIND to:TO add:ADD module:MODULE
     - `__OVERLAY_COUNT`: Number of overlays.
     - `ARM9_CTOR_START`: Base address of .ctor in main ARM9 program.
     - `__exception_table_start__`: Base address of .exceptix in main ARM9 program.
-    - `__exception_table_start__`: End address of .exceptix in main ARM9 program.
+    - `__exception_table_end__`: End address of .exceptix in main ARM9 program.
 
 ### Destination module
 - `none`: No destination symbol found due to poor analysis by `dsd init`. Many `dsd` subcommands will fail.

--- a/docs/relocs.md
+++ b/docs/relocs.md
@@ -28,6 +28,8 @@ from:FROM kind:KIND to:TO add:ADD module:MODULE
     - `__CODE_HI`: End address of static memory in main RAM.
     - `__OVERLAY_COUNT`: Number of overlays.
     - `ARM9_CTOR_START`: Base address of .ctor in main ARM9 program.
+    - `__exception_table_start__`: Base address of .exceptix in main ARM9 program.
+    - `__exception_table_start__`: End address of .exceptix in main ARM9 program.
 
 ### Destination module
 - `none`: No destination symbol found due to poor analysis by `dsd init`. Many `dsd` subcommands will fail.

--- a/lib/src/analysis/data.rs
+++ b/lib/src/analysis/data.rs
@@ -103,6 +103,11 @@ pub fn find_local_data_from_pools(
                     continue;
                 }
 
+                if relocations.get(pool_constant.address).is_some() {
+                    // This relocation was already found in a previous analysis phase
+                    return Ok(());
+                }
+
                 // Relocate function pointer
                 let reloc =
                     relocations.add_load(pool_constant.address, pointer, 0, module_kind.into())?;

--- a/lib/src/analysis/exception.rs
+++ b/lib/src/analysis/exception.rs
@@ -9,12 +9,13 @@ use crate::{
     util::bytes::FromSlice,
 };
 
-pub struct ExceptionData {
+pub struct ExceptionData<'a> {
     pub exception_start: Option<u32>,
     pub find_exception_table_fn: &'static FindExceptionTableFn,
     pub find_exception_table_fn_addr: u32,
     pub exceptix_start: u32,
     pub exceptix_end: u32,
+    pub exception_table: &'a [ExceptionTableEntry],
 }
 
 pub struct FindExceptionTableFn {
@@ -53,11 +54,11 @@ const FIND_EXCEPTION_TABLE_FUNCTIONS: &[FindExceptionTableFn] = &[
 
 #[repr(C)]
 #[derive(Zeroable, Pod, Clone, Copy)]
-struct ExceptionTableEntry {
-    function_start: u32,
-    function_length: u32,
+pub struct ExceptionTableEntry {
+    pub function_address: u32,
+    pub function_length: u32,
     /// This is a pointer if `(function_length & 1) == 0`, otherwise it's the whole exception record.
-    exception_record: u32,
+    pub exception_record: u32,
 }
 
 impl ExceptionTableEntry {
@@ -80,9 +81,9 @@ pub enum ExceptionDataError {
     DsRomBuildInfo { source: RawBuildInfoError },
 }
 
-impl ExceptionData {
+impl<'a> ExceptionData<'a> {
     pub fn analyze(
-        arm9: &Arm9,
+        arm9: &'a Arm9,
         unknown_autoloads: &[&Autoload],
     ) -> Result<Option<Self>, ExceptionDataError> {
         let arm9_code = arm9.code()?;
@@ -125,6 +126,7 @@ impl ExceptionData {
             find_exception_table_fn_addr,
             exceptix_start,
             exceptix_end,
+            exception_table,
         }))
     }
 

--- a/lib/src/analysis/exception.rs
+++ b/lib/src/analysis/exception.rs
@@ -4,23 +4,28 @@ use bytemuck::{Pod, Zeroable};
 use ds_rom::rom::{Arm9, Autoload, raw::RawBuildInfoError};
 use snafu::Snafu;
 
-use crate::{config::section::SectionCodeError, util::bytes::FromSlice};
+use crate::{
+    config::{module::FIND_EXCEPTION_TABLE_SYMBOL_NAME, section::SectionCodeError},
+    util::bytes::FromSlice,
+};
 
 pub struct ExceptionData {
-    exception_start: Option<u32>,
-    exceptix_start: u32,
-    exceptix_end: u32,
+    pub exception_start: Option<u32>,
+    pub find_exception_table_fn: &'static FindExceptionTableFn,
+    pub find_exception_table_fn_addr: u32,
+    pub exceptix_start: u32,
+    pub exceptix_end: u32,
 }
 
-struct GetExceptixFunction {
-    code: &'static [u8],
+pub struct FindExceptionTableFn {
+    pub code: &'static [u8],
     // Offset of pool constants to the start and end of .exceptix
-    start_offset: u32,
-    end_offset: u32,
+    pub exceptix_start_offset: u32,
+    pub exceptix_end_offset: u32,
 }
 
-const GET_EXCEPTIX_FUNCTIONS: &[GetExceptixFunction] = &[
-    GetExceptixFunction {
+const FIND_EXCEPTION_TABLE_FUNCTIONS: &[FindExceptionTableFn] = &[
+    FindExceptionTableFn {
         code: &[
             0x10, 0x20, 0x9f, 0xe5, // ldr r2, [pc, #0x10]
             0x10, 0x10, 0x9f, 0xe5, // ldr r1, [pc, #0x10]
@@ -29,10 +34,10 @@ const GET_EXCEPTIX_FUNCTIONS: &[GetExceptixFunction] = &[
             0x01, 0x00, 0xa0, 0xe3, // mov r0, #1
             0x1e, 0xff, 0x2f, 0xe1, // bx lr
         ],
-        start_offset: 0x18,
-        end_offset: 0x1c,
+        exceptix_start_offset: 0x18,
+        exceptix_end_offset: 0x1c,
     },
-    GetExceptixFunction {
+    FindExceptionTableFn {
         code: &[
             0x02, 0x49, // ldr r1, [pc, #0x8]
             0xc1, 0x60, // str r1, [r0, #0xc]
@@ -41,8 +46,8 @@ const GET_EXCEPTIX_FUNCTIONS: &[GetExceptixFunction] = &[
             0x01, 0x20, // movs r0, #1
             0x70, 0x47, // bx lr
         ],
-        start_offset: 0xc,
-        end_offset: 0x10,
+        exceptix_start_offset: 0xc,
+        exceptix_end_offset: 0x10,
     },
 ];
 
@@ -82,18 +87,25 @@ impl ExceptionData {
     ) -> Result<Option<Self>, ExceptionDataError> {
         let arm9_code = arm9.code()?;
 
-        let mut exceptix_result = Self::find_get_exceptix_function(arm9_code, arm9.base_address())?;
+        let mut exceptix_result =
+            Self::find_exception_table_function(arm9_code, arm9.base_address())?;
         if exceptix_result.is_none() {
             for autoload in unknown_autoloads {
                 exceptix_result =
-                    Self::find_get_exceptix_function(autoload.code(), autoload.base_address())?;
+                    Self::find_exception_table_function(autoload.code(), autoload.base_address())?;
                 if exceptix_result.is_some() {
                     break;
                 }
             }
         }
 
-        let Some((exceptix_start, exceptix_end)) = exceptix_result else {
+        let Some((
+            find_exception_table_fn,
+            find_exception_table_fn_addr,
+            exceptix_start,
+            exceptix_end,
+        )) = exceptix_result
+        else {
             return Ok(None);
         };
 
@@ -107,13 +119,19 @@ impl ExceptionData {
         let exception_start =
             exception_table.iter().filter_map(|entry| entry.exception_record_pointer()).min();
 
-        Ok(Some(ExceptionData { exception_start, exceptix_start, exceptix_end }))
+        Ok(Some(ExceptionData {
+            exception_start,
+            find_exception_table_fn,
+            find_exception_table_fn_addr,
+            exceptix_start,
+            exceptix_end,
+        }))
     }
 
-    fn find_get_exceptix_function(
+    pub fn find_exception_table_function(
         module_code: &[u8],
         base_address: u32,
-    ) -> Result<Option<(u32, u32)>, ExceptionDataError> {
+    ) -> Result<Option<(&'static FindExceptionTableFn, u32, u32, u32)>, ExceptionDataError> {
         let end_address = base_address + module_code.len() as u32;
         log::debug!(
             "Searching for exception table in {:#010x}..{:#010x}",
@@ -123,7 +141,7 @@ impl ExceptionData {
 
         for address in (base_address..end_address).step_by(4) {
             let code = &module_code[(address - base_address) as usize..];
-            let Some(get_exceptix) = GET_EXCEPTIX_FUNCTIONS
+            let Some(find_exception_table_fn) = FIND_EXCEPTION_TABLE_FUNCTIONS
                 .iter()
                 .find(|get_exceptix| code.starts_with(get_exceptix.code))
             else {
@@ -131,33 +149,24 @@ impl ExceptionData {
             };
 
             let exceptix_start = u32::from_le_slice(
-                &code[get_exceptix.start_offset as usize..get_exceptix.start_offset as usize + 4],
+                &code[find_exception_table_fn.exceptix_start_offset as usize
+                    ..find_exception_table_fn.exceptix_start_offset as usize + 4],
             );
             let exceptix_end = u32::from_le_slice(
-                &code[get_exceptix.end_offset as usize..get_exceptix.end_offset as usize + 4],
+                &code[find_exception_table_fn.exceptix_end_offset as usize
+                    ..find_exception_table_fn.exceptix_end_offset as usize + 4],
             );
 
             log::debug!(
-                "Found get_exceptix function at {:#010x} with exceptix start {:#010x} and end {:#010x}",
+                "Found {} function at {:#010x} with .exceptix start {:#010x} and end {:#010x}",
+                FIND_EXCEPTION_TABLE_SYMBOL_NAME,
                 address,
                 exceptix_start,
                 exceptix_end
             );
 
-            return Ok(Some((exceptix_start, exceptix_end)));
+            return Ok(Some((find_exception_table_fn, address, exceptix_start, exceptix_end)));
         }
         Ok(None)
-    }
-
-    pub fn exception_start(&self) -> Option<u32> {
-        self.exception_start
-    }
-
-    pub fn exceptix_start(&self) -> u32 {
-        self.exceptix_start
-    }
-
-    pub fn exceptix_end(&self) -> u32 {
-        self.exceptix_end
     }
 }

--- a/lib/src/analysis/mod.rs
+++ b/lib/src/analysis/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod ctor;
 pub(crate) mod data;
-pub(crate) mod exception;
+pub mod exception;
 mod function_branch;
 mod function_start;
 pub mod functions;

--- a/lib/src/config/delinks.rs
+++ b/lib/src/config/delinks.rs
@@ -71,9 +71,13 @@ impl Delinks {
             context.row = line.row;
             if line.text.trim().is_empty() {
                 continue;
-            } else if let Some(delink_file) =
-                Self::try_parse_delink_file(&line, &mut lines, &mut context, &sections)?
-            {
+            } else if let Some(delink_file) = Self::try_parse_delink_file(
+                &line,
+                &mut lines,
+                &mut context,
+                &sections,
+                module_kind,
+            )? {
                 files.push(delink_file);
                 break;
             } else if let Some(new_categories) = Categories::try_parse(&line) {
@@ -92,9 +96,13 @@ impl Delinks {
 
             if line.text.trim().is_empty() {
                 continue;
-            } else if let Some(delink_file) =
-                Self::try_parse_delink_file(&line, &mut lines, &mut context, &sections)?
-            {
+            } else if let Some(delink_file) = Self::try_parse_delink_file(
+                &line,
+                &mut lines,
+                &mut context,
+                &sections,
+                module_kind,
+            )? {
                 files.push(delink_file);
             }
         }
@@ -107,9 +115,10 @@ impl Delinks {
         lines: &mut Peekable<CommentedLineIterator>,
         context: &mut ParseContext,
         sections: &Sections,
+        module_kind: ModuleKind,
     ) -> Result<Option<DelinkFile>, DelinkFileParseError> {
         if line.text.chars().next().is_some_and(|c| !c.is_whitespace()) {
-            let delink_file = DelinkFile::parse(line, lines, context, sections)?;
+            let delink_file = DelinkFile::parse(line, lines, context, sections, module_kind)?;
             Ok(Some(delink_file))
         } else {
             Ok(None)
@@ -207,6 +216,7 @@ impl DelinkFile {
         lines: &mut Peekable<CommentedLineIterator>,
         context: &mut ParseContext,
         inherit_sections: &Sections,
+        module_kind: ModuleKind,
     ) -> Result<Self, DelinkFileParseError> {
         let name = first_line
             .text
@@ -241,7 +251,8 @@ impl DelinkFile {
             } else if let Some(new_categories) = Categories::try_parse(&line) {
                 categories.extend(new_categories);
             } else {
-                let section = Section::parse_inherit(&line, context, inherit_sections)?;
+                let section =
+                    Section::parse_inherit(&line, context, inherit_sections, module_kind)?;
                 sections.add(section).map_err(|error| {
                     delink_file_parse_error::SectionsSnafu { context: context.clone(), error }
                         .build()

--- a/lib/src/config/link_time_const.rs
+++ b/lib/src/config/link_time_const.rs
@@ -13,13 +13,15 @@ pub enum LinkTimeConst {
     CodeHi,
     OverlayCount,
     Arm9CtorStart,
+    ExceptionTableStart,
+    ExceptionTableEnd,
 }
 
 #[derive(Debug, Snafu)]
 pub enum LinkTimeConstParseError {
     #[snafu(display(
         "{context}: unknown link-time constant '{value}', must be one of:
-        __DTCM_LO, __ITCM_HI, __CODE_HI, __OVERLAY_COUNT, ARM9_CTOR_START:
+        __DTCM_LO, __ITCM_HI, __CODE_HI, __OVERLAY_COUNT, ARM9_CTOR_START, __exception_table_start__, __exception_table_end__:
         {backtrace}"
     ))]
     UnknownKind { context: ParseContext, value: String, backtrace: Backtrace },
@@ -36,6 +38,8 @@ impl LinkTimeConst {
             "__CODE_HI" => Ok(Self::CodeHi),
             "__OVERLAY_COUNT" => Ok(Self::OverlayCount),
             "ARM9_CTOR_START" => Ok(Self::Arm9CtorStart),
+            "__exception_table_start__" => Ok(Self::ExceptionTableStart),
+            "__exception_table_end__" => Ok(Self::ExceptionTableEnd),
             _ => UnknownKindSnafu { context, value }.fail(),
         }
     }
@@ -49,6 +53,8 @@ impl Display for LinkTimeConst {
             LinkTimeConst::CodeHi => write!(f, "__CODE_HI"),
             LinkTimeConst::OverlayCount => write!(f, "__OVERLAY_COUNT"),
             LinkTimeConst::Arm9CtorStart => write!(f, "ARM9_CTOR_START"),
+            LinkTimeConst::ExceptionTableStart => write!(f, "__exception_table_start__"),
+            LinkTimeConst::ExceptionTableEnd => write!(f, "__exception_table_end__"),
         }
     }
 }

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -1,7 +1,7 @@
 use std::{
     backtrace::Backtrace,
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet, btree_map},
+    collections::{BTreeMap, BTreeSet},
     fmt::Display,
     str::Utf8Error,
 };
@@ -940,10 +940,10 @@ impl Module {
                 exception_data.find_exception_table_fn_addr,
                 exception_data.find_exception_table_fn,
                 symbol_map,
-                &mut functions,
             )?
         {
             text_end = u32::max(text_end, function.end_address());
+            functions.insert(exception_data.find_exception_table_fn_addr, function);
         }
 
         self.add_text_section(FoundFunctions { functions, start: text_start, end: text_end })?;
@@ -1017,43 +1017,38 @@ impl Module {
         Ok(())
     }
 
-    fn analyze_find_exception_table_fn<'a>(
+    pub fn analyze_find_exception_table_fn(
         &mut self,
         find_fn_address: u32,
         find_fn: &FindExceptionTableFn,
         symbol_map: &mut SymbolMap,
-        functions: &'a mut BTreeMap<u32, Function>,
-    ) -> Result<Option<&'a Function>, ModuleError> {
+    ) -> Result<Option<Function>, ModuleError> {
         if (self.base_address()..self.end_address()).contains(&find_fn_address) {
-            let function = match functions.entry(find_fn_address) {
-                btree_map::Entry::Vacant(entry) => {
-                    let function = Function::parse_function(FunctionParseOptions {
-                        name: FIND_EXCEPTION_TABLE_SYMBOL_NAME.to_string(),
-                        start_address: find_fn_address,
-                        base_address: self.base_address,
-                        module_code: &self.code,
-                        known_end_address: None,
-                        module_start_address: self.base_address,
-                        module_end_address: self.end_address(),
-                        existing_functions: None,
-                        dsprot_encrypted_ranges: &[],
-                        check_defs_uses: false,
-                        parse_options: ParseFunctionOptions::default(),
-                    })?;
-                    symbol_map.add_function(&function);
-                    function.add_local_symbols_to_map(symbol_map)?;
-                    entry.insert(function);
-                    functions.get(&find_fn_address).unwrap()
-                }
-                btree_map::Entry::Occupied(_entry) => {
-                    symbol_map
-                        .rename_by_address(find_fn_address, FIND_EXCEPTION_TABLE_SYMBOL_NAME)?;
-                    // entry.get() causes borrow checker error, polonius might fix this
-                    functions.get(&find_fn_address).unwrap()
-                }
-            };
+            let function = Function::parse_function(FunctionParseOptions {
+                name: FIND_EXCEPTION_TABLE_SYMBOL_NAME.to_string(),
+                start_address: find_fn_address,
+                base_address: self.base_address,
+                module_code: &self.code,
+                known_end_address: None,
+                module_start_address: self.base_address,
+                module_end_address: self.end_address(),
+                existing_functions: None,
+                dsprot_encrypted_ranges: &[],
+                check_defs_uses: false,
+                parse_options: ParseFunctionOptions::default(),
+            })?;
+
+            if let Some((id, _)) = symbol_map.by_address(find_fn_address)? {
+                symbol_map.remove(id);
+            }
+            symbol_map.add_function(&function);
+
+            let reloc_from_exceptix_start = find_fn_address + find_fn.exceptix_start_offset;
+            let reloc_from_exceptix_end = find_fn_address + find_fn.exceptix_end_offset;
+            self.relocations.remove(reloc_from_exceptix_start);
+            self.relocations.remove(reloc_from_exceptix_end);
             self.relocations.add(Relocation::new(RelocationOptions {
-                from: find_fn_address + find_fn.exceptix_start_offset,
+                from: reloc_from_exceptix_start,
                 to: 0,
                 addend: 0,
                 kind: RelocationKind::LinkTimeConst(LinkTimeConst::ExceptionTableStart),
@@ -1061,7 +1056,7 @@ impl Module {
                 comments: Default::default(),
             }))?;
             self.relocations.add(Relocation::new(RelocationOptions {
-                from: find_fn_address + find_fn.exceptix_end_offset,
+                from: reloc_from_exceptix_end,
                 to: 0,
                 addend: 0,
                 kind: RelocationKind::LinkTimeConst(LinkTimeConst::ExceptionTableEnd),
@@ -1150,14 +1145,11 @@ impl Module {
         // Ensure __FindExceptionTable function is analyzed
         if let Some((find_fn, find_fn_addr, _, _)) =
             ExceptionData::find_exception_table_function(&self.code, self.base_address)?
-            && let Some(function) = self.analyze_find_exception_table_fn(
-                find_fn_addr,
-                find_fn,
-                symbol_map,
-                &mut functions,
-            )?
+            && let Some(function) =
+                self.analyze_find_exception_table_fn(find_fn_addr, find_fn, symbol_map)?
         {
             text_end = u32::max(text_end, function.end_address());
+            functions.insert(find_fn_addr, function);
         }
 
         if !functions.is_empty() {

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -1,7 +1,7 @@
 use std::{
     backtrace::Backtrace,
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, btree_map},
     fmt::Display,
     str::Utf8Error,
 };
@@ -29,7 +29,7 @@ use crate::{
     analysis::{
         ctor::{CtorRange, CtorRangeError},
         data::{self, FindLocalDataOptions, find_function_labels},
-        exception::{ExceptionData, ExceptionDataError},
+        exception::{ExceptionData, ExceptionDataError, FindExceptionTableFn},
         functions::{
             FindFunctionsOptions, Function, FunctionAnalysisError, FunctionParseOptions,
             FunctionSearchOptions, IntoFunctionError, ParseFunctionError, ParseFunctionOptions,
@@ -123,6 +123,7 @@ pub const MAIN_FN_SYMBOL_NAME: &str = "main";
 pub const BUILD_INFO_SYMBOL_NAME: &str = "BuildInfo";
 pub const AUTOLOAD_CALLBACK_SYMBOL_NAME: &str = "AutoloadCallback";
 pub const OVERLAY_SIGNATURES_SYMBOL_NAME: &str = "OverlaySignatures";
+pub const FIND_EXCEPTION_TABLE_SYMBOL_NAME: &str = "__FindExceptionTable";
 
 pub struct OverlayModuleOptions<'a> {
     pub id: u16,
@@ -886,7 +887,7 @@ impl Module {
         functions.extend(entry_functions);
 
         // All other functions, starting from main
-        let exception_start = exception_data.as_ref().and_then(ExceptionData::exception_start);
+        let exception_start = exception_data.as_ref().and_then(|e| e.exception_start);
         let text_max = exception_start.unwrap_or(read_only_end);
         let build_info_end = self.find_build_info_end_address(arm9)?;
 
@@ -903,7 +904,7 @@ impl Module {
             dsprot_encrypted_ranges,
             ..Default::default()
         };
-        let FoundFunctions { functions: text_functions, end: text_end, .. } = self
+        let FoundFunctions { functions: text_functions, end: mut text_end, .. } = self
             .find_functions(
                 symbol_map,
                 &FunctionSearchOptions {
@@ -933,16 +934,28 @@ impl Module {
             functions.extend(pre_main.functions);
         }
 
+        // Ensure __FindExceptionTable function is analyzed
+        if let Some(exception_data) = &exception_data
+            && let Some(function) = self.analyze_find_exception_table_fn(
+                exception_data.find_exception_table_fn_addr,
+                exception_data.find_exception_table_fn,
+                symbol_map,
+                &mut functions,
+            )?
+        {
+            text_end = u32::max(text_end, function.end_address());
+        }
+
         self.add_text_section(FoundFunctions { functions, start: text_start, end: text_end })?;
 
         // Add .exception and .exceptix sections if they exist
         let text_exceptix_end = if let Some(exception_data) = exception_data {
-            if let Some(exception_start) = exception_data.exception_start() {
+            if let Some(exception_start) = exception_data.exception_start {
                 self.sections.add(Section::new(SectionOptions {
                     name: ".exception".to_string(),
                     kind: SectionKind::Rodata,
                     start_address: exception_start,
-                    end_address: exception_data.exceptix_start(),
+                    end_address: exception_data.exceptix_start,
                     alignment: 1,
                     functions: None,
                     comments: Comments::new(),
@@ -952,14 +965,14 @@ impl Module {
             self.sections.add(Section::new(SectionOptions {
                 name: ".exceptix".to_string(),
                 kind: SectionKind::Rodata,
-                start_address: exception_data.exceptix_start(),
-                end_address: exception_data.exceptix_end(),
+                start_address: exception_data.exceptix_start,
+                end_address: exception_data.exceptix_end,
                 alignment: 4,
                 functions: None,
                 comments: Comments::new(),
             })?)?;
 
-            exception_data.exceptix_end()
+            exception_data.exceptix_end
         } else {
             text_end
         };
@@ -1002,6 +1015,63 @@ impl Module {
         }
 
         Ok(())
+    }
+
+    fn analyze_find_exception_table_fn<'a>(
+        &mut self,
+        find_fn_address: u32,
+        find_fn: &FindExceptionTableFn,
+        symbol_map: &mut SymbolMap,
+        functions: &'a mut BTreeMap<u32, Function>,
+    ) -> Result<Option<&'a Function>, ModuleError> {
+        if (self.base_address()..self.end_address()).contains(&find_fn_address) {
+            let function = match functions.entry(find_fn_address) {
+                btree_map::Entry::Vacant(entry) => {
+                    let function = Function::parse_function(FunctionParseOptions {
+                        name: FIND_EXCEPTION_TABLE_SYMBOL_NAME.to_string(),
+                        start_address: find_fn_address,
+                        base_address: self.base_address,
+                        module_code: &self.code,
+                        known_end_address: None,
+                        module_start_address: self.base_address,
+                        module_end_address: self.end_address(),
+                        existing_functions: None,
+                        dsprot_encrypted_ranges: &[],
+                        check_defs_uses: false,
+                        parse_options: ParseFunctionOptions::default(),
+                    })?;
+                    symbol_map.add_function(&function);
+                    function.add_local_symbols_to_map(symbol_map)?;
+                    entry.insert(function);
+                    functions.get(&find_fn_address).unwrap()
+                }
+                btree_map::Entry::Occupied(_entry) => {
+                    symbol_map
+                        .rename_by_address(find_fn_address, FIND_EXCEPTION_TABLE_SYMBOL_NAME)?;
+                    // entry.get() causes borrow checker error, polonius might fix this
+                    functions.get(&find_fn_address).unwrap()
+                }
+            };
+            self.relocations.add(Relocation::new(RelocationOptions {
+                from: find_fn_address + find_fn.exceptix_start_offset,
+                to: 0,
+                addend: 0,
+                kind: RelocationKind::LinkTimeConst(LinkTimeConst::ExceptionTableStart),
+                module: RelocationModule::Main,
+                comments: Default::default(),
+            }))?;
+            self.relocations.add(Relocation::new(RelocationOptions {
+                from: find_fn_address + find_fn.exceptix_end_offset,
+                to: 0,
+                addend: 0,
+                kind: RelocationKind::LinkTimeConst(LinkTimeConst::ExceptionTableEnd),
+                module: RelocationModule::Main,
+                comments: Default::default(),
+            }))?;
+            Ok(Some(function))
+        } else {
+            Ok(None)
+        }
     }
 
     fn find_build_info_end_address(&self, arm9: &Arm9) -> Result<u32, ModuleError> {
@@ -1061,7 +1131,7 @@ impl Module {
         };
         let code = autoload.code();
 
-        let text_functions = self.find_functions(
+        let (mut functions, mut text_end) = if let Some(f) = self.find_functions(
             symbol_map,
             &FunctionSearchOptions {
                 max_function_start_search_distance: 32,
@@ -1071,15 +1141,32 @@ impl Module {
                 ..Default::default()
             },
             &self.default_func_prefix.clone(),
-        )?;
-
-        let text_end = if let Some(text_functions) = text_functions {
-            let text_end = text_functions.end;
-            self.add_text_section(text_functions)?;
-            text_end
+        )? {
+            (f.functions, f.end)
         } else {
-            self.base_address
+            (BTreeMap::new(), self.base_address)
         };
+
+        // Ensure __FindExceptionTable function is analyzed
+        if let Some((find_fn, find_fn_addr, _, _)) =
+            ExceptionData::find_exception_table_function(&self.code, self.base_address)?
+            && let Some(function) = self.analyze_find_exception_table_fn(
+                find_fn_addr,
+                find_fn,
+                symbol_map,
+                &mut functions,
+            )?
+        {
+            text_end = u32::max(text_end, function.end_address());
+        }
+
+        if !functions.is_empty() {
+            self.add_text_section(FoundFunctions {
+                functions,
+                start: self.base_address,
+                end: text_end,
+            })?;
+        }
 
         let rodata_start = text_end.next_multiple_of(4);
         let rodata_end = rodata_start.next_multiple_of(32);

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -29,7 +29,7 @@ use crate::{
     analysis::{
         ctor::{CtorRange, CtorRangeError},
         data::{self, FindLocalDataOptions, find_function_labels},
-        exception::{ExceptionData, ExceptionDataError, FindExceptionTableFn},
+        exception::{ExceptionData, ExceptionDataError, ExceptionTableEntry, FindExceptionTableFn},
         functions::{
             FindFunctionsOptions, Function, FunctionAnalysisError, FunctionParseOptions,
             FunctionSearchOptions, IntoFunctionError, ParseFunctionError, ParseFunctionOptions,
@@ -971,6 +971,24 @@ impl Module {
                 functions: None,
                 comments: Comments::new(),
             })?)?;
+
+            for (i, entry) in exception_data.exception_table.iter().enumerate() {
+                let address = exception_data.exceptix_start
+                    + (i * std::mem::size_of::<ExceptionTableEntry>()) as u32;
+                symbol_map.add_data(
+                    Some(format!("@EX@{:08x}", entry.function_address)),
+                    address,
+                    SymData::Word { count: Some(3) },
+                )?;
+
+                if (entry.function_length & 1) == 0 {
+                    symbol_map.add_data(
+                        Some(format!("@ET@{:08x}", entry.function_address)),
+                        entry.exception_record,
+                        SymData::Any,
+                    )?;
+                }
+            }
 
             exception_data.exceptix_end
         } else {

--- a/lib/src/config/section.rs
+++ b/lib/src/config/section.rs
@@ -248,13 +248,14 @@ impl Section {
         line: &CommentedLine,
         context: &ParseContext,
         sections: &Sections,
+        module_kind: ModuleKind,
     ) -> Result<Self, SectionInheritParseError> {
         let mut words = iter_words(&line.text);
         let Some(name) = words.next() else {
             return EmptyLineSnafu { context: context.clone() }.fail()?;
         };
 
-        let migrate_section = MigrateSection::parse(name)?;
+        let migrate_section = MigrateSection::parse(name, module_kind)?;
 
         let inherit_section = match migrate_section {
             None => Some(
@@ -475,12 +476,16 @@ pub enum MigrateSection {
     Itcm,
     AutoloadData(u32),
     AutoloadBss(u32),
+    Exception,
+    Exceptix,
 }
 
 const DTCM_SECTION: &str = ".dtcm";
 const ITCM_SECTION: &str = ".itcm";
 const AUTOLOAD_DATA_SECTION_PREFIX: &str = ".autodata_";
 const AUTOLOAD_BSS_SECTION_PREFIX: &str = ".autobss_";
+const EXCEPTION_SECTION: &str = ".exception";
+const EXCEPTIX_SECTION: &str = ".exceptix";
 
 #[derive(Debug, Snafu)]
 pub enum MigrateSectionError {
@@ -489,10 +494,12 @@ pub enum MigrateSectionError {
 }
 
 impl MigrateSection {
-    pub fn parse(name: &str) -> Result<Option<Self>, MigrateSectionError> {
+    pub fn parse(name: &str, src_module: ModuleKind) -> Result<Option<Self>, MigrateSectionError> {
         match name {
             DTCM_SECTION => Ok(Some(Self::Dtcm)),
             ITCM_SECTION => Ok(Some(Self::Itcm)),
+            EXCEPTION_SECTION if src_module != ModuleKind::Arm9 => Ok(Some(Self::Exception)),
+            EXCEPTIX_SECTION if src_module != ModuleKind::Arm9 => Ok(Some(Self::Exceptix)),
             _ => {
                 if let Some(index) = name.strip_prefix(AUTOLOAD_DATA_SECTION_PREFIX) {
                     let index: u32 = index.parse().map_err(|error| {
@@ -521,6 +528,8 @@ impl MigrateSection {
             MigrateSection::AutoloadBss(index) => {
                 format!("{AUTOLOAD_BSS_SECTION_PREFIX}{index}").into()
             }
+            MigrateSection::Exception => EXCEPTION_SECTION.into(),
+            MigrateSection::Exceptix => EXCEPTIX_SECTION.into(),
         }
     }
 
@@ -530,6 +539,8 @@ impl MigrateSection {
             MigrateSection::Itcm => ".text",
             MigrateSection::AutoloadData(_) => ".data",
             MigrateSection::AutoloadBss(_) => ".bss",
+            MigrateSection::Exception => EXCEPTION_SECTION,
+            MigrateSection::Exceptix => EXCEPTIX_SECTION,
         }
     }
 
@@ -551,6 +562,8 @@ impl MigrateSection {
             MigrateSection::Itcm => SectionKind::Code,
             MigrateSection::AutoloadData(_) => SectionKind::Data,
             MigrateSection::AutoloadBss(_) => SectionKind::Bss,
+            MigrateSection::Exception => SectionKind::Rodata,
+            MigrateSection::Exceptix => SectionKind::Rodata,
         }
     }
 
@@ -561,6 +574,8 @@ impl MigrateSection {
             MigrateSection::AutoloadData(index) | MigrateSection::AutoloadBss(index) => {
                 ModuleKind::Autoload(AutoloadKind::Unknown(*index))
             }
+            MigrateSection::Exception => ModuleKind::Arm9,
+            MigrateSection::Exceptix => ModuleKind::Arm9,
         }
     }
 }


### PR DESCRIPTION
This adds the link-time constants `__exception_table_start__` and `__exception_table_end__` which map to the start and end address of the `.exceptix` section in ARM9 main.

Some games define exceptions in overlays, or outside ARM9 main in other words. Since all exception data belong in ARM9 main, dsd now move `.exception` and `.exceptix` sections from other modules to ARM9 main, similar to how `.itcm` and `.dtcm` are moved.

Additionally, to ensure proper `.exceptix` output, the LCF now uses the `EXCEPTION` command rather than list all the `.exceptix` objects directly, which is standard for the C++ runtime used by the DS. Note that `EXCEPTION` will emit all the `.exceptix` contents from all objects, but not the symbols. This means that pre-existing relocations pointing to the start/end of `.exceptix` will be cleared to zero by the linker, as those symbols are effectively dead-stripped.

To remedy this, a migration was added (`dsd fix find-exceptix`) which automatically migrate established dsd projects to use the new link-time constants. To assist in exception decompilation, it will also add symbols for the `__FindExceptionTable` function and the `.exception` and `.exceptix` symbols themselves. `dsd init` was also updated to do the same.

Closes #61 