### PR TITLE
Handle overlay .text with embedded data

### DIFF
--- a/cli/src/analysis/data.rs
+++ b/cli/src/analysis/data.rs
@@ -4,7 +4,9 @@ use ds_decomp::{
         module::{Module, ModuleKind},
         relocations::{Relocation, RelocationFromModulesError, RelocationModule},
         section::{SectionCodeError, SectionIndex, SectionKind},
-        symbol::{InstructionMode, SymFunction, SymLabel, SymbolKind, SymbolMapError, SymbolMaps},
+        symbol::{
+            InstructionMode, SymFunction, SymLabel, Symbol, SymbolKind, SymbolMapError, SymbolMaps,
+        },
     },
 };
 use snafu::Snafu;
@@ -22,13 +24,14 @@ pub enum AnalyzeExternalReferencesError {
     ))]
     LocalFunctionNotFound { from: u32, to: u32, module_kind: ModuleKind },
     #[snafu(display(
-        "Failed to add relocation for function call from {from:#010x} in {from_module} to {to:#010x} in {to_module} as it leads to a non-function symbol"
+        "Failed to add relocation for function call from {from:#010x} in {from_module} to {to:#010x} in {to_module} as it leads to a non-function symbol: {symbol}"
     ))]
     InvalidCallDestinationSymbol {
         from: u32,
         to: u32,
         from_module: ModuleKind,
         to_module: ModuleKind,
+        symbol: Box<Symbol>,
     },
     #[snafu(transparent)]
     SymbolMap { source: SymbolMapError },
@@ -131,6 +134,7 @@ fn add_function_calls_as_relocations(
                         to: called_function.address,
                         from_module: module_kind,
                         to_module: module_kind,
+                        symbol: symbol.clone(),
                     }
                     .fail();
                 }

--- a/lib/src/analysis/data.rs
+++ b/lib/src/analysis/data.rs
@@ -280,7 +280,9 @@ fn insert_unknown_function_symbols(
         }
 
         let module_kind = local_module.kind();
-        if symbol_map.get_function_containing(called_function.address).is_none() {
+        if symbol_map.get_function_containing(called_function.address).is_none()
+            && symbol_map.get_label(called_function.address)?.is_none()
+        {
             log::warn!(
                 "Local function call from {:#010x} in {} to {:#010x} leads to no function, inserting an unknown function symbol",
                 address,
@@ -314,20 +316,32 @@ fn add_external_labels(
         }
 
         let module_kind = module.kind();
-        let symbol = match symbol_map.get_function_containing(called_function.address) {
-            Some((_, symbol)) => symbol,
-            None => {
-                let error = LocalFunctionNotFoundSnafu {
-                    from: address,
-                    to: called_function.address,
-                    module_kind,
-                }
-                .build();
-                log::error!("{error}");
-                return Err(error);
+        let symbol = if let Some((_, symbol)) =
+            symbol_map.get_function_containing(called_function.address)
+        {
+            symbol
+        } else if symbol_map.get_label(called_function.address)?.is_some() {
+            log::warn!(
+                "Local function call from {:#010x} in {} to {:#010x} leads to a label, updating the label to be external",
+                address,
+                module_kind,
+                called_function.address,
+            );
+            let (_, symbol) =
+                symbol_map.add_external_label(called_function.address, called_function.thumb)?;
+            symbol
+        } else {
+            let error = LocalFunctionNotFoundSnafu {
+                from: address,
+                to: called_function.address,
+                module_kind,
             }
+            .build();
+            log::error!("{error}");
+            return Err(error);
         };
-        if called_function.address != symbol.addr {
+        if called_function.address != symbol.addr && matches!(symbol.kind, SymbolKind::Function(_))
+        {
             log::warn!(
                 "Local function call from {:#010x} in {} to {:#010x} goes to middle of function '{}' at {:#010x}, adding an external label symbol",
                 address,

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -33,6 +33,7 @@ pub type PoolConstants = BTreeMap<u32, PoolConstant>;
 pub type JumpTables = BTreeMap<u32, JumpTable>;
 pub type InlineTables = BTreeMap<u32, InlineTable>;
 pub type FunctionCalls = BTreeMap<u32, CalledFunction>;
+pub type Branches = BTreeMap<u32, Branch>;
 pub type DataLoads = BTreeMap<u32, u32>;
 
 #[derive(Debug, Clone)]
@@ -49,6 +50,7 @@ pub struct Function {
     jump_tables: JumpTables,
     inline_tables: InlineTables,
     function_calls: FunctionCalls,
+    branches: Branches,
     dsprot_encryption: dsprot::EncryptionType,
     dsprot_encrypted_ranges: Vec<dsprot::EncryptedRange>,
 }
@@ -162,6 +164,28 @@ impl Function {
             }
             _ => None,
         }
+    }
+
+    /// Decodes the single instruction at `address` and returns its destination if it is an
+    /// unconditional branch. Used to look through trampolines, which cannot be parsed as functions
+    /// until their destination is known.
+    pub fn unconditional_branch_destination(
+        base_address: u32,
+        module_code: &[u8],
+        address: u32,
+    ) -> Option<u32> {
+        let code = module_code.get(address.checked_sub(base_address)? as usize..)?;
+        let parse_mode = if Self::is_thumb_function(address, code) {
+            ParseMode::Thumb
+        } else {
+            ParseMode::Arm
+        };
+        let mut parser = Parser::new(parse_mode, address, Endian::Little, PARSE_FLAGS, code);
+        let (address, ins, parsed_ins) = parser.next()?;
+        if ins.is_conditional() {
+            return None;
+        }
+        Self::is_branch(ins, &parsed_ins, address)
     }
 
     fn function_parser_loop(
@@ -357,7 +381,7 @@ impl Function {
                         address,
                         source
                     );
-                    address += 4;
+                    address += parse_mode.instruction_size(0) as u32;
                     function_code = &module_code[(address - base_address) as usize..];
                     continue;
                 }
@@ -576,6 +600,7 @@ impl Function {
                     jump_tables: JumpTables::new(),
                     inline_tables: InlineTables::new(),
                     function_calls: FunctionCalls::new(),
+                    branches: Branches::new(),
                     dsprot_encryption: dsprot::EncryptionType::None,
                     dsprot_encrypted_ranges: Vec::new(),
                 };
@@ -659,6 +684,11 @@ impl Function {
         &self.function_calls
     }
 
+    /// Every `b` instruction in this function, including the ones which branch within it.
+    pub fn branches(&self) -> &Branches {
+        &self.branches
+    }
+
     pub fn dsprot_encryption(&self) -> dsprot::EncryptionType {
         self.dsprot_encryption
     }
@@ -723,6 +753,7 @@ struct ParseFunctionContext<'a> {
     jump_tables: JumpTables,
     inline_tables: InlineTables,
     function_calls: FunctionCalls,
+    branches: Branches,
 
     module_start_address: u32,
     module_end_address: u32,
@@ -817,6 +848,7 @@ impl<'a> ParseFunctionContext<'a> {
             jump_tables: JumpTables::new(),
             inline_tables: InlineTables::new(),
             function_calls: FunctionCalls::new(),
+            branches: Branches::new(),
 
             module_start_address,
             module_end_address,
@@ -1002,6 +1034,11 @@ impl<'a> ParseFunctionContext<'a> {
                     self.last_conditional_destination.max(Some(end_address));
             } else {
                 if let Some(destination) = Function::is_branch(ins, parsed_ins, address) {
+                    self.branches.insert(address, Branch {
+                        ins,
+                        address: destination,
+                        thumb: self.thumb,
+                    });
                     let outside_function =
                         destination < self.start_address || destination >= end_address;
                     if outside_function {
@@ -1037,6 +1074,7 @@ impl<'a> ParseFunctionContext<'a> {
 
         self.function_branch_state = self.function_branch_state.handle(ins, parsed_ins);
         if let Some(destination) = Function::is_branch(ins, parsed_ins, address) {
+            self.branches.insert(address, Branch { ins, address: destination, thumb: self.thumb });
             let in_current_module =
                 destination >= self.module_start_address && destination < self.module_end_address;
             if !in_current_module {
@@ -1356,6 +1394,7 @@ impl<'a> ParseFunctionContext<'a> {
             jump_tables: self.jump_tables,
             inline_tables: self.inline_tables,
             function_calls: self.function_calls,
+            branches: self.branches,
             dsprot_encryption: dsprot::EncryptionType::None,
             dsprot_encrypted_ranges: Vec::new(),
         })
@@ -1595,6 +1634,14 @@ pub struct FunctionSearchOptions<'a> {
 
 #[derive(Clone, Copy, Debug)]
 pub struct CalledFunction {
+    pub ins: Ins,
+    pub address: u32,
+    pub thumb: bool,
+}
+
+/// A `b` instruction made by a function, whether it stays inside the function or leaves it.
+#[derive(Clone, Copy, Debug)]
+pub struct Branch {
     pub ins: Ins,
     pub address: u32,
     pub thumb: bool,

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -33,7 +33,6 @@ pub type PoolConstants = BTreeMap<u32, PoolConstant>;
 pub type JumpTables = BTreeMap<u32, JumpTable>;
 pub type InlineTables = BTreeMap<u32, InlineTable>;
 pub type FunctionCalls = BTreeMap<u32, CalledFunction>;
-pub type Branches = BTreeMap<u32, Branch>;
 pub type DataLoads = BTreeMap<u32, u32>;
 
 #[derive(Debug, Clone)]
@@ -50,7 +49,6 @@ pub struct Function {
     jump_tables: JumpTables,
     inline_tables: InlineTables,
     function_calls: FunctionCalls,
-    branches: Branches,
     dsprot_encryption: dsprot::EncryptionType,
     dsprot_encrypted_ranges: Vec<dsprot::EncryptedRange>,
 }
@@ -166,29 +164,73 @@ impl Function {
         }
     }
 
-    /// Decodes the single instruction at `address` and returns its destination if it is an
-    /// unconditional branch. Used to look through trampolines, which cannot be parsed as functions
-    /// until their destination is known.
-    pub fn unconditional_branch_destination(
-        base_address: u32,
-        module_code: &[u8],
-        address: u32,
-    ) -> Option<u32> {
-        let code = module_code.get(address.checked_sub(base_address)? as usize..)?;
-        let parse_mode = if Self::is_thumb_function(address, code) {
-            ParseMode::Thumb
-        } else {
-            ParseMode::Arm
-        };
-        let mut parser = Parser::new(parse_mode, address, Endian::Little, PARSE_FLAGS, code);
+    /// Builds the one-instruction function for a trampoline: a function consisting of a single
+    /// unconditional branch. Returns [`None`] if the function does not start with such a branch.
+    fn as_trampoline(
+        options: &FunctionParseOptions,
+        mode: ParseMode,
+        found_functions: &BTreeMap<u32, Function>,
+    ) -> Option<Function> {
+        let start_address = options.start_address;
+        let offset = start_address.checked_sub(options.base_address)? as usize;
+        let code = options.module_code.get(offset..)?;
+        let mut parser = Parser::new(mode, start_address, Endian::Little, PARSE_FLAGS, code);
         let (address, ins, parsed_ins) = parser.next()?;
         if ins.is_conditional() {
             return None;
         }
-        Self::is_branch(ins, &parsed_ins, address)
+        let destination = Self::is_branch(ins, &parsed_ins, address)?;
+        if destination < options.module_start_address || destination >= options.module_end_address {
+            return None;
+        }
+        // A trampoline branches to the start of a function. A branch into the middle of one is a
+        // label, which means this is data being misread as a single-instruction function.
+        let inside_known_function = found_functions
+            .range(..destination)
+            .next_back()
+            .is_some_and(|(_, function)| destination < function.end_address());
+        if inside_known_function {
+            return None;
+        }
+
+        let thumb = mode == ParseMode::Thumb;
+        let end_address = start_address + mode.instruction_size(0) as u32;
+        let mut function_calls = FunctionCalls::new();
+        function_calls.insert(address, CalledFunction { ins, address: destination, thumb });
+        Some(Function {
+            name: options.name.clone(),
+            start_address,
+            end_address: options.known_end_address.unwrap_or(end_address),
+            first_instruction_address: start_address,
+            last_instruction_address: end_address,
+            thumb,
+            labels: Labels::new(),
+            pool_constants: PoolConstants::new(),
+            jump_tables: JumpTables::new(),
+            inline_tables: InlineTables::new(),
+            function_calls,
+            dsprot_encryption: dsprot::EncryptionType::None,
+            dsprot_encrypted_ranges: Vec::new(),
+        })
     }
 
     fn function_parser_loop(
+        parser: Parser<'_>,
+        options: FunctionParseOptions,
+        found_functions: &BTreeMap<u32, Function>,
+    ) -> Result<Function, FunctionAnalysisError> {
+        // A trampoline has no epilogue and is usually followed directly by data, so parsing it as a
+        // normal function walks into that data and fails. Only fall back to classifying it as one
+        // when the normal parse does fail: a function which merely starts with a branch, such as
+        // one whose entry jumps into the middle of a loop, must keep its real boundaries.
+        let trampoline = Self::as_trampoline(&options, parser.mode, found_functions);
+        match Self::function_parser_loop_inner(parser, options, found_functions) {
+            Ok(function) => Ok(function),
+            Err(error) => trampoline.ok_or(error),
+        }
+    }
+
+    fn function_parser_loop_inner(
         mut parser: Parser<'_>,
         options: FunctionParseOptions,
         found_functions: &BTreeMap<u32, Function>,
@@ -600,7 +642,6 @@ impl Function {
                     jump_tables: JumpTables::new(),
                     inline_tables: InlineTables::new(),
                     function_calls: FunctionCalls::new(),
-                    branches: Branches::new(),
                     dsprot_encryption: dsprot::EncryptionType::None,
                     dsprot_encrypted_ranges: Vec::new(),
                 };
@@ -684,11 +725,6 @@ impl Function {
         &self.function_calls
     }
 
-    /// Every `b` instruction in this function, including the ones which branch within it.
-    pub fn branches(&self) -> &Branches {
-        &self.branches
-    }
-
     pub fn dsprot_encryption(&self) -> dsprot::EncryptionType {
         self.dsprot_encryption
     }
@@ -753,7 +789,6 @@ struct ParseFunctionContext<'a> {
     jump_tables: JumpTables,
     inline_tables: InlineTables,
     function_calls: FunctionCalls,
-    branches: Branches,
 
     module_start_address: u32,
     module_end_address: u32,
@@ -848,7 +883,6 @@ impl<'a> ParseFunctionContext<'a> {
             jump_tables: JumpTables::new(),
             inline_tables: InlineTables::new(),
             function_calls: FunctionCalls::new(),
-            branches: Branches::new(),
 
             module_start_address,
             module_end_address,
@@ -887,13 +921,6 @@ impl<'a> ParseFunctionContext<'a> {
         ins: Ins,
         parsed_ins: &ParsedIns,
     ) -> ParseFunctionState {
-        if self.known_end_address.is_some_and(|end| address >= end) {
-            // The function's size is already known (e.g. from symbols.txt) and parsing has reached
-            // its end; functions with no epilogue (trampolines, handwritten assembly) would
-            // otherwise run into whatever follows them.
-            self.end_address = Some(address);
-            return ParseFunctionState::Done;
-        }
         if self.pool_constants.contains_key(&address) {
             parser.seek_forward(address + 4);
             return ParseFunctionState::Continue;
@@ -1034,11 +1061,6 @@ impl<'a> ParseFunctionContext<'a> {
                     self.last_conditional_destination.max(Some(end_address));
             } else {
                 if let Some(destination) = Function::is_branch(ins, parsed_ins, address) {
-                    self.branches.insert(address, Branch {
-                        ins,
-                        address: destination,
-                        thumb: self.thumb,
-                    });
                     let outside_function =
                         destination < self.start_address || destination >= end_address;
                     if outside_function {
@@ -1074,7 +1096,6 @@ impl<'a> ParseFunctionContext<'a> {
 
         self.function_branch_state = self.function_branch_state.handle(ins, parsed_ins);
         if let Some(destination) = Function::is_branch(ins, parsed_ins, address) {
-            self.branches.insert(address, Branch { ins, address: destination, thumb: self.thumb });
             let in_current_module =
                 destination >= self.module_start_address && destination < self.module_end_address;
             if !in_current_module {
@@ -1089,11 +1110,6 @@ impl<'a> ParseFunctionContext<'a> {
                     .existing_functions
                     .map(|functions| functions.contains_key(&destination))
                     .unwrap_or(false)
-                // If the function's size is already known, any branch outside of its range must be
-                // a tail call to another function.
-                || self
-                    .known_end_address
-                    .is_some_and(|end| destination >= end || destination < self.start_address)
             {
                 if !ins.is_conditional() && !in_conditional_block {
                     // This is an unconditional backwards function branch, which means this function has ended
@@ -1394,7 +1410,6 @@ impl<'a> ParseFunctionContext<'a> {
             jump_tables: self.jump_tables,
             inline_tables: self.inline_tables,
             function_calls: self.function_calls,
-            branches: self.branches,
             dsprot_encryption: dsprot::EncryptionType::None,
             dsprot_encrypted_ranges: Vec::new(),
         })
@@ -1634,14 +1649,6 @@ pub struct FunctionSearchOptions<'a> {
 
 #[derive(Clone, Copy, Debug)]
 pub struct CalledFunction {
-    pub ins: Ins,
-    pub address: u32,
-    pub thumb: bool,
-}
-
-/// A `b` instruction made by a function, whether it stays inside the function or leaves it.
-#[derive(Clone, Copy, Debug)]
-pub struct Branch {
     pub ins: Ins,
     pub address: u32,
     pub thumb: bool,

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -164,8 +164,8 @@ impl Function {
         }
     }
 
-    /// Builds the one-instruction function for a trampoline: a function consisting of a single
-    /// unconditional branch. Returns [`None`] if the function does not start with such a branch.
+    /// Builds a function consisting of a single unconditional branch to the start of another
+    /// function. Returns [`None`] if not applicable.
     fn as_trampoline(
         options: &FunctionParseOptions,
         mode: ParseMode,
@@ -183,13 +183,12 @@ impl Function {
         if destination < options.module_start_address || destination >= options.module_end_address {
             return None;
         }
-        // A trampoline branches to the start of a function. A branch into the middle of one is a
-        // label, which means this is data being misread as a single-instruction function.
         let inside_known_function = found_functions
             .range(..destination)
             .next_back()
             .is_some_and(|(_, function)| destination < function.end_address());
         if inside_known_function {
+            // Not a trampoline, it branches to the middle of another function
             return None;
         }
 
@@ -219,20 +218,26 @@ impl Function {
         options: FunctionParseOptions,
         found_functions: &BTreeMap<u32, Function>,
     ) -> Result<Function, FunctionAnalysisError> {
-        // A trampoline has no epilogue and is usually followed directly by data, so parsing it as a
-        // normal function walks into that data and fails. Only fall back to classifying it as one
-        // when the normal parse does fail: a function which merely starts with a branch, such as
-        // one whose entry jumps into the middle of a loop, must keep its real boundaries.
-        let trampoline = Self::as_trampoline(&options, parser.mode, found_functions);
-        match Self::function_parser_loop_inner(parser, options, found_functions) {
+        match Self::function_parser_loop_inner(parser, &options, found_functions) {
             Ok(function) => Ok(function),
-            Err(error) => trampoline.ok_or(error),
+            Err(error) => {
+                // Trampolines have no return instruction and is usually followed by data, leading
+                // to this error. We only check for trampolines here as regular functions can start
+                // with `b <label>` but should not trigger analysis errors.
+                if let Some(trampoline) =
+                    Self::as_trampoline(&options, parser.mode, found_functions)
+                {
+                    Ok(trampoline)
+                } else {
+                    Err(error)
+                }
+            }
         }
     }
 
     fn function_parser_loop_inner(
         mut parser: Parser<'_>,
-        options: FunctionParseOptions,
+        options: &FunctionParseOptions,
         found_functions: &BTreeMap<u32, Function>,
     ) -> Result<Function, FunctionAnalysisError> {
         let thumb = parser.mode == ParseMode::Thumb;
@@ -416,8 +421,7 @@ impl Function {
                 Err(FunctionAnalysisError::IntoFunction {
                     source: IntoFunctionError::ParseFunction { source },
                 }) if search_options.function_addresses.is_some() => {
-                    // In seeded mode, a candidate that fails to parse should not end the entire
-                    // search; skip to the next seed instead.
+                    // Skip to next candidate function instead of terminating search.
                     log::debug!(
                         "Skipping function candidate at {:#010x} that failed to parse: {}",
                         address,
@@ -779,7 +783,7 @@ pub struct FindFunctionsOptions<'a> {
 }
 
 struct ParseFunctionContext<'a> {
-    name: String,
+    name: &'a str,
     start_address: u32,
     thumb: bool,
     end_address: Option<u32>,
@@ -839,7 +843,7 @@ pub enum IntoFunctionError {
 impl<'a> ParseFunctionContext<'a> {
     pub fn new(
         thumb: bool,
-        options: FunctionParseOptions<'a>,
+        options: &'a FunctionParseOptions<'a>,
         found_functions: &'a BTreeMap<u32, Function>,
     ) -> Self {
         let FunctionParseOptions {
@@ -874,22 +878,22 @@ impl<'a> ParseFunctionContext<'a> {
 
         Self {
             name,
-            start_address,
+            start_address: *start_address,
             thumb,
             end_address: None,
-            known_end_address,
+            known_end_address: *known_end_address,
             labels: Labels::new(),
             pool_constants: PoolConstants::new(),
             jump_tables: JumpTables::new(),
             inline_tables: InlineTables::new(),
             function_calls: FunctionCalls::new(),
 
-            module_start_address,
-            module_end_address,
-            existing_functions,
+            module_start_address: *module_start_address,
+            module_end_address: *module_end_address,
+            existing_functions: *existing_functions,
             found_functions,
             dsprot_encrypted_ranges,
-            base_address,
+            base_address: *base_address,
             code: module_code,
 
             last_conditional_destination: None,
@@ -904,7 +908,7 @@ impl<'a> ParseFunctionContext<'a> {
             inline_table_state: Default::default(),
             illegal_code_state: Default::default(),
 
-            check_defs_uses,
+            check_defs_uses: *check_defs_uses,
             defined_registers,
             register_values: [None; 16],
 
@@ -1399,7 +1403,7 @@ impl<'a> ParseFunctionContext<'a> {
         }
 
         Ok(Function {
-            name: self.name,
+            name: self.name.to_string(),
             start_address: self.start_address,
             end_address,
             first_instruction_address: self.start_address,

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -59,6 +59,10 @@ pub enum FunctionAnalysisError {
     IntoFunction { source: IntoFunctionError },
     #[snafu(transparent)]
     SymbolMap { source: SymbolMapError },
+    #[snafu(display(
+        "Cannot parse function at {function_address:#010x} because it is out of bounds {min_address:#010x}..{max_address:#010x}"
+    ))]
+    FunctionOutOfBounds { function_address: u32, min_address: u32, max_address: u32 },
 }
 
 const PARSE_FLAGS: ParseFlags = ParseFlags { version: ArmVersion::V5Te, ual: false };
@@ -193,6 +197,25 @@ impl Function {
         }
 
         let thumb = mode == ParseMode::Thumb;
+        let valid_destination = Function::parse_function(FunctionParseOptions {
+            name: "trampoline_destination".to_string(),
+            start_address: destination,
+            base_address: options.base_address,
+            module_code: options.module_code,
+            known_end_address: None,
+            module_start_address: options.module_start_address,
+            module_end_address: options.module_end_address,
+            existing_functions: None,
+            dsprot_encrypted_ranges: &[],
+            check_defs_uses: true,
+            parse_options: ParseFunctionOptions { thumb: Some(thumb) },
+        })
+        .is_ok();
+        if !valid_destination {
+            // Fake branch, not valid code at branch destination
+            return None;
+        }
+
         let end_address = start_address + mode.instruction_size(0) as u32;
         let mut function_calls = FunctionCalls::new();
         function_calls.insert(address, CalledFunction { ins, address: destination, thumb });
@@ -293,11 +316,18 @@ impl Function {
         } = &options;
 
         let start = (start_address - base_address) as usize;
+        let function_code = module_code.get(start..).ok_or_else(|| {
+            FunctionOutOfBoundsSnafu {
+                function_address: *start_address,
+                min_address: *base_address,
+                max_address: base_address + module_code.len() as u32,
+            }
+            .build()
+        })?;
         let thumb = parse_options
             .thumb
-            .unwrap_or(Function::is_thumb_function(*start_address, &module_code[start..]));
+            .unwrap_or(Function::is_thumb_function(*start_address, function_code));
         let parse_mode = if thumb { ParseMode::Thumb } else { ParseMode::Arm };
-        let function_code = &module_code[start..];
         let parser =
             Parser::new(parse_mode, *start_address, Endian::Little, PARSE_FLAGS, function_code);
 

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -349,6 +349,20 @@ impl Function {
                 Ok(function) => function,
                 Err(FunctionAnalysisError::IntoFunction {
                     source: IntoFunctionError::ParseFunction { source },
+                }) if search_options.function_addresses.is_some() => {
+                    // In seeded mode, a candidate that fails to parse should not end the entire
+                    // search; skip to the next seed instead.
+                    log::debug!(
+                        "Skipping function candidate at {:#010x} that failed to parse: {}",
+                        address,
+                        source
+                    );
+                    address += 4;
+                    function_code = &module_code[(address - base_address) as usize..];
+                    continue;
+                }
+                Err(FunctionAnalysisError::IntoFunction {
+                    source: IntoFunctionError::ParseFunction { source },
                 }) => {
                     match source {
                         ParseFunctionError::IllegalIns {
@@ -841,6 +855,13 @@ impl<'a> ParseFunctionContext<'a> {
         ins: Ins,
         parsed_ins: &ParsedIns,
     ) -> ParseFunctionState {
+        if self.known_end_address.is_some_and(|end| address >= end) {
+            // The function's size is already known (e.g. from symbols.txt) and parsing has reached
+            // its end; functions with no epilogue (trampolines, handwritten assembly) would
+            // otherwise run into whatever follows them.
+            self.end_address = Some(address);
+            return ParseFunctionState::Done;
+        }
         if self.pool_constants.contains_key(&address) {
             parser.seek_forward(address + 4);
             return ParseFunctionState::Continue;
@@ -1030,6 +1051,11 @@ impl<'a> ParseFunctionContext<'a> {
                     .existing_functions
                     .map(|functions| functions.contains_key(&destination))
                     .unwrap_or(false)
+                // If the function's size is already known, any branch outside of its range must be
+                // a tail call to another function.
+                || self
+                    .known_end_address
+                    .is_some_and(|end| destination >= end || destination < self.start_address)
             {
                 if !ins.is_conditional() && !in_conditional_block {
                     // This is an unconditional backwards function branch, which means this function has ended

--- a/lib/src/config/mod.rs
+++ b/lib/src/config/mod.rs
@@ -147,7 +147,7 @@ pub(crate) fn strip_parens(text: &str) -> &str {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default, Debug)]
 pub struct Comments {
     /// Lines of comments or blank lines that precede the main text line.
     pub pre_lines: Vec<String>,

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -26,6 +26,7 @@ use super::{
     symbol::{SymData, SymbolKind, SymbolMap, SymbolMapError, SymbolMaps},
 };
 use crate::{
+    util::bytes::FromSlice,
     analysis::{
         ctor::{CtorRange, CtorRangeError},
         data::{self, FindLocalDataOptions, find_function_labels},
@@ -770,6 +771,75 @@ impl Module {
             },
             &self.default_func_prefix.clone(),
         )? {
+            // The linear sweep stops at the first data blob embedded in .text (data pointers become
+            // upper bounds and the function start search gives up inside non-code). Some games (e.g.
+            // Sonic Colors) place tables between functions, leaving most of .text undiscovered.
+            // Follow unconditional local calls that land beyond the sweep end to resume the search
+            // after each blob, until no new functions are found.
+            loop {
+                let undiscovered = |functions: &BTreeMap<u32, Function>, address: u32| {
+                    address < rodata_end
+                        && !functions
+                            .range(..=address)
+                            .next_back()
+                            .is_some_and(|(_, function)| address < function.end_address())
+                };
+                let mut seeds: BTreeSet<u32> = functions_result
+                    .functions
+                    .values()
+                    .flat_map(|function| function.function_calls().iter())
+                    .filter(|(_, called)| !called.ins.is_conditional())
+                    .map(|(_, called)| called.address & !1)
+                    .filter(|&address| undiscovered(&functions_result.functions, address))
+                    .collect();
+                // Trampolines (a single unconditional branch followed by inline data) fail to
+                // parse until their destination is a known function, so seed their destinations
+                // as well.
+                let trampoline_destinations: Vec<u32> = seeds
+                    .iter()
+                    .filter_map(|&address| {
+                        let offset = (address - self.base_address) as usize;
+                        let word = u32::from_le_slice(self.code.get(offset..offset + 4)?);
+                        if word & 0xff000000 == 0xea000000 {
+                            let branch_offset = (((word & 0xffffff) << 8) as i32) >> 6;
+                            let destination = address.wrapping_add_signed(branch_offset + 8);
+                            undiscovered(&functions_result.functions, destination)
+                                .then_some(destination)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                seeds.extend(trampoline_destinations);
+                if seeds.is_empty() {
+                    break;
+                }
+                let num_functions = functions_result.functions.len();
+                if let Some(more_functions) = self.find_functions(
+                    symbol_map,
+                    &FunctionSearchOptions {
+                        end_address: Some(rodata_end),
+                        // Seeds are known call/branch targets, so unlike the linear sweep there is
+                        // no risk of analyzing data as code. Some targets are handwritten assembly
+                        // that does not follow the procedure call standard.
+                        check_defs_uses: false,
+                        function_addresses: Some(&seeds),
+                        existing_functions: Some(&functions_result.functions),
+                        overriden_function_sizes: Some(overriden_function_sizes),
+                        dsprot_encrypted_functions: Some(dsprot_encrypted_functions),
+                        dsprot_encrypted_ranges,
+                        ..Default::default()
+                    },
+                    &self.default_func_prefix.clone(),
+                )? {
+                    functions_result.functions.extend(more_functions.functions);
+                    functions_result.end = functions_result.end.max(more_functions.end);
+                }
+                if functions_result.functions.len() == num_functions {
+                    break;
+                }
+            }
+
             let end = functions_result.end;
             // Force to base address to avoid misaligned start address
             functions_result.start = self.base_address;

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -26,7 +26,6 @@ use super::{
     symbol::{SymData, SymbolKind, SymbolMap, SymbolMapError, SymbolMaps},
 };
 use crate::{
-    util::bytes::FromSlice,
     analysis::{
         ctor::{CtorRange, CtorRangeError},
         data::{self, FindLocalDataOptions, find_function_labels},
@@ -725,6 +724,106 @@ impl Module {
         Ok(())
     }
 
+    /// Collects the destinations of unconditional calls and branches which are not covered by any
+    /// discovered function, to be used as seeds for another function search.
+    fn find_analysis_seeds(
+        &self,
+        functions: &BTreeMap<u32, Function>,
+        end_address: u32,
+    ) -> BTreeSet<u32> {
+        let undiscovered = |address: u32| {
+            // Only addresses inside this module's code can be analyzed, and anything at or past
+            // `end_address` is not code at all.
+            address >= self.base_address
+                && address < end_address
+                && !functions
+                    .range(..=address)
+                    .next_back()
+                    .is_some_and(|(_, function)| address < function.end_address())
+        };
+        let mut seeds: BTreeSet<u32> = functions
+            .values()
+            .flat_map(|function| {
+                let calls =
+                    function.function_calls().values().map(|called| (called.ins, called.address));
+                let branches =
+                    function.branches().values().map(|branch| (branch.ins, branch.address));
+                calls.chain(branches)
+            })
+            .filter(|(ins, _)| !ins.is_conditional())
+            .map(|(_, address)| address & !1)
+            .filter(|&address| undiscovered(address))
+            .collect();
+        // A trampoline (a single unconditional branch followed by inline data) does not parse as a
+        // function until its destination is known, so its branch is never recorded above. Look
+        // through the seeds which start with one and seed their destinations as well.
+        let trampoline_destinations = seeds
+            .iter()
+            .filter_map(|&address| {
+                let destination = Function::unconditional_branch_destination(
+                    self.base_address,
+                    &self.code,
+                    address,
+                )?;
+                undiscovered(destination).then_some(destination)
+            })
+            .collect::<Vec<_>>();
+        seeds.extend(trampoline_destinations);
+        seeds
+    }
+
+    /// The linear function sweep stops at the first data blob embedded in .text: pointers to the
+    /// blob become upper bounds, and the function start search gives up inside non-code. Some games
+    /// (e.g. Sonic Colors) place tables between functions, which leaves most of .text undiscovered.
+    ///
+    /// This resumes the search after each blob by seeding new searches with call and branch
+    /// destinations that no discovered function covers, repeating until no new functions are found.
+    fn find_functions_from_seeds(
+        &mut self,
+        symbol_map: &mut SymbolMap,
+        functions_result: &mut FoundFunctions,
+        options: &SeededSearchOptions,
+    ) -> Result<(), ModuleError> {
+        for pass in 1..=MAX_SEEDED_SEARCH_PASSES {
+            let seeds = self.find_analysis_seeds(&functions_result.functions, options.end_address);
+            if seeds.is_empty() {
+                break;
+            }
+            let num_functions = functions_result.functions.len();
+            if let Some(more_functions) = self.find_functions(
+                symbol_map,
+                &FunctionSearchOptions {
+                    end_address: Some(options.end_address),
+                    // Seeds are known call/branch targets, so unlike the linear sweep there is no
+                    // risk of analyzing data as code. Some targets are handwritten assembly that
+                    // does not follow the procedure call standard.
+                    check_defs_uses: false,
+                    function_addresses: Some(&seeds),
+                    existing_functions: Some(&functions_result.functions),
+                    overriden_function_sizes: Some(options.overriden_function_sizes),
+                    dsprot_encrypted_functions: Some(options.dsprot_encrypted_functions),
+                    dsprot_encrypted_ranges: options.dsprot_encrypted_ranges,
+                    ..Default::default()
+                },
+                &self.default_func_prefix.clone(),
+            )? {
+                functions_result.functions.extend(more_functions.functions);
+                functions_result.end = functions_result.end.max(more_functions.end);
+            }
+            if functions_result.functions.len() == num_functions {
+                break;
+            }
+            if pass == MAX_SEEDED_SEARCH_PASSES {
+                log::warn!(
+                    "Seeded function search in {} did not settle after {} passes, giving up",
+                    self.kind,
+                    MAX_SEEDED_SEARCH_PASSES
+                );
+            }
+        }
+        Ok(())
+    }
+
     fn find_sections_overlay(
         &mut self,
         symbol_map: &mut SymbolMap,
@@ -771,74 +870,16 @@ impl Module {
             },
             &self.default_func_prefix.clone(),
         )? {
-            // The linear sweep stops at the first data blob embedded in .text (data pointers become
-            // upper bounds and the function start search gives up inside non-code). Some games (e.g.
-            // Sonic Colors) place tables between functions, leaving most of .text undiscovered.
-            // Follow unconditional local calls that land beyond the sweep end to resume the search
-            // after each blob, until no new functions are found.
-            loop {
-                let undiscovered = |functions: &BTreeMap<u32, Function>, address: u32| {
-                    address < rodata_end
-                        && !functions
-                            .range(..=address)
-                            .next_back()
-                            .is_some_and(|(_, function)| address < function.end_address())
-                };
-                let mut seeds: BTreeSet<u32> = functions_result
-                    .functions
-                    .values()
-                    .flat_map(|function| function.function_calls().iter())
-                    .filter(|(_, called)| !called.ins.is_conditional())
-                    .map(|(_, called)| called.address & !1)
-                    .filter(|&address| undiscovered(&functions_result.functions, address))
-                    .collect();
-                // Trampolines (a single unconditional branch followed by inline data) fail to
-                // parse until their destination is a known function, so seed their destinations
-                // as well.
-                let trampoline_destinations: Vec<u32> = seeds
-                    .iter()
-                    .filter_map(|&address| {
-                        let offset = (address - self.base_address) as usize;
-                        let word = u32::from_le_slice(self.code.get(offset..offset + 4)?);
-                        if word & 0xff000000 == 0xea000000 {
-                            let branch_offset = (((word & 0xffffff) << 8) as i32) >> 6;
-                            let destination = address.wrapping_add_signed(branch_offset + 8);
-                            undiscovered(&functions_result.functions, destination)
-                                .then_some(destination)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                seeds.extend(trampoline_destinations);
-                if seeds.is_empty() {
-                    break;
-                }
-                let num_functions = functions_result.functions.len();
-                if let Some(more_functions) = self.find_functions(
-                    symbol_map,
-                    &FunctionSearchOptions {
-                        end_address: Some(rodata_end),
-                        // Seeds are known call/branch targets, so unlike the linear sweep there is
-                        // no risk of analyzing data as code. Some targets are handwritten assembly
-                        // that does not follow the procedure call standard.
-                        check_defs_uses: false,
-                        function_addresses: Some(&seeds),
-                        existing_functions: Some(&functions_result.functions),
-                        overriden_function_sizes: Some(overriden_function_sizes),
-                        dsprot_encrypted_functions: Some(dsprot_encrypted_functions),
-                        dsprot_encrypted_ranges,
-                        ..Default::default()
-                    },
-                    &self.default_func_prefix.clone(),
-                )? {
-                    functions_result.functions.extend(more_functions.functions);
-                    functions_result.end = functions_result.end.max(more_functions.end);
-                }
-                if functions_result.functions.len() == num_functions {
-                    break;
-                }
-            }
+            self.find_functions_from_seeds(
+                symbol_map,
+                &mut functions_result,
+                &SeededSearchOptions {
+                    end_address: rodata_end,
+                    overriden_function_sizes,
+                    dsprot_encrypted_functions,
+                    dsprot_encrypted_ranges,
+                },
+            )?;
 
             let end = functions_result.end;
             // Force to base address to avoid misaligned start address
@@ -1516,6 +1557,21 @@ struct FoundFunctions {
     functions: BTreeMap<u32, Function>,
     start: u32,
     end: u32,
+}
+
+/// Maximum number of passes in [`Module::find_functions_from_seeds`]. Every pass but the last one
+/// discovers at least one function, so this is never reached in practice; the cap only exists so a
+/// future change cannot turn the loop into an infinite one.
+const MAX_SEEDED_SEARCH_PASSES: usize = 100;
+
+/// The [`FunctionSearchOptions`] which [`Module::find_functions_from_seeds`] cannot derive on its
+/// own.
+struct SeededSearchOptions<'a> {
+    /// Address to end the search at, i.e. the start of .rodata.
+    end_address: u32,
+    overriden_function_sizes: &'a BTreeMap<u32, u32>,
+    dsprot_encrypted_functions: &'a BTreeMap<u32, dsprot::EncryptionType>,
+    dsprot_encrypted_ranges: &'a [dsprot::EncryptedRange],
 }
 
 /// Sorted list of .init function addresses

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -724,8 +724,9 @@ impl Module {
         Ok(())
     }
 
-    /// Collects the destinations of unconditional calls and branches which are not covered by any
-    /// discovered function, to be used as seeds for another function search.
+    /// Collects the destinations of unconditional function calls which are not covered by any
+    /// discovered function, to be used as seeds for another function search. Tail calls and a
+    /// trampoline's branch are recorded as function calls too, so those are included.
     fn find_analysis_seeds(
         &self,
         functions: &BTreeMap<u32, Function>,
@@ -741,35 +742,13 @@ impl Module {
                     .next_back()
                     .is_some_and(|(_, function)| address < function.end_address())
         };
-        let mut seeds: BTreeSet<u32> = functions
+        functions
             .values()
-            .flat_map(|function| {
-                let calls =
-                    function.function_calls().values().map(|called| (called.ins, called.address));
-                let branches =
-                    function.branches().values().map(|branch| (branch.ins, branch.address));
-                calls.chain(branches)
-            })
-            .filter(|(ins, _)| !ins.is_conditional())
-            .map(|(_, address)| address & !1)
+            .flat_map(|function| function.function_calls().values())
+            .filter(|called| !called.ins.is_conditional())
+            .map(|called| called.address & !1)
             .filter(|&address| undiscovered(address))
-            .collect();
-        // A trampoline (a single unconditional branch followed by inline data) does not parse as a
-        // function until its destination is known, so its branch is never recorded above. Look
-        // through the seeds which start with one and seed their destinations as well.
-        let trampoline_destinations = seeds
-            .iter()
-            .filter_map(|&address| {
-                let destination = Function::unconditional_branch_destination(
-                    self.base_address,
-                    &self.code,
-                    address,
-                )?;
-                undiscovered(destination).then_some(destination)
-            })
-            .collect::<Vec<_>>();
-        seeds.extend(trampoline_destinations);
-        seeds
+            .collect()
     }
 
     /// The linear function sweep stops at the first data blob embedded in .text: pointers to the

--- a/lib/src/config/module.rs
+++ b/lib/src/config/module.rs
@@ -724,63 +724,56 @@ impl Module {
         Ok(())
     }
 
-    /// Collects the destinations of unconditional function calls which are not covered by any
-    /// discovered function, to be used as seeds for another function search. Tail calls and a
-    /// trampoline's branch are recorded as function calls too, so those are included.
-    fn find_analysis_seeds(
+    /// Finds addresses of undiscovered functions by looking at all known function calls. Any call
+    /// destination that belongs to this module but isn't recorded in `functions` is considered
+    /// undiscovered.
+    fn undiscovered_functions(
         &self,
         functions: &BTreeMap<u32, Function>,
-        end_address: u32,
+        end_address: Option<u32>,
     ) -> BTreeSet<u32> {
-        let undiscovered = |address: u32| {
-            // Only addresses inside this module's code can be analyzed, and anything at or past
-            // `end_address` is not code at all.
-            address >= self.base_address
-                && address < end_address
-                && !functions
-                    .range(..=address)
-                    .next_back()
-                    .is_some_and(|(_, function)| address < function.end_address())
-        };
         functions
             .values()
             .flat_map(|function| function.function_calls().values())
             .filter(|called| !called.ins.is_conditional())
             .map(|called| called.address & !1)
-            .filter(|&address| undiscovered(address))
+            .filter(|&address| {
+                address >= self.base_address
+                    && address < end_address.unwrap_or(self.end_address())
+                    && !functions
+                        .range(..=address)
+                        .next_back()
+                        .is_some_and(|(_, function)| address < function.end_address())
+            })
             .collect()
     }
 
-    /// The linear function sweep stops at the first data blob embedded in .text: pointers to the
-    /// blob become upper bounds, and the function start search gives up inside non-code. Some games
-    /// (e.g. Sonic Colors) place tables between functions, which leaves most of .text undiscovered.
-    ///
-    /// This resumes the search after each blob by seeding new searches with call and branch
-    /// destinations that no discovered function covers, repeating until no new functions are found.
-    fn find_functions_from_seeds(
+    /// Repeats function analysis until there are no function calls leading to undiscovered
+    /// functions in this module.
+    fn find_undiscovered_functions(
         &mut self,
         symbol_map: &mut SymbolMap,
         functions_result: &mut FoundFunctions,
-        options: &SeededSearchOptions,
+        options: &FindUndiscoveredFunctionsOptions,
     ) -> Result<(), ModuleError> {
-        for pass in 1..=MAX_SEEDED_SEARCH_PASSES {
-            let seeds = self.find_analysis_seeds(&functions_result.functions, options.end_address);
-            if seeds.is_empty() {
+        for pass in 1..=MAX_UNDISCOVERED_SEARCH_PASSES {
+            let undiscovered =
+                self.undiscovered_functions(&functions_result.functions, options.end_address);
+            if undiscovered.is_empty() {
                 break;
             }
             let num_functions = functions_result.functions.len();
             if let Some(more_functions) = self.find_functions(
                 symbol_map,
                 &FunctionSearchOptions {
-                    end_address: Some(options.end_address),
-                    // Seeds are known call/branch targets, so unlike the linear sweep there is no
-                    // risk of analyzing data as code. Some targets are handwritten assembly that
-                    // does not follow the procedure call standard.
+                    end_address: options.end_address,
+                    // `function_addresses` are known call/branch targets, so there is no risk of
+                    // analyzing data as code.
                     check_defs_uses: false,
-                    function_addresses: Some(&seeds),
+                    function_addresses: Some(&undiscovered),
                     existing_functions: Some(&functions_result.functions),
-                    overriden_function_sizes: Some(options.overriden_function_sizes),
-                    dsprot_encrypted_functions: Some(options.dsprot_encrypted_functions),
+                    overriden_function_sizes: options.overriden_function_sizes,
+                    dsprot_encrypted_functions: options.dsprot_encrypted_functions,
                     dsprot_encrypted_ranges: options.dsprot_encrypted_ranges,
                     ..Default::default()
                 },
@@ -792,11 +785,11 @@ impl Module {
             if functions_result.functions.len() == num_functions {
                 break;
             }
-            if pass == MAX_SEEDED_SEARCH_PASSES {
+            if pass == MAX_UNDISCOVERED_SEARCH_PASSES {
                 log::warn!(
-                    "Seeded function search in {} did not settle after {} passes, giving up",
+                    "Undiscovered function search in {} did not settle after {} passes, giving up",
                     self.kind,
-                    MAX_SEEDED_SEARCH_PASSES
+                    MAX_UNDISCOVERED_SEARCH_PASSES
                 );
             }
         }
@@ -849,13 +842,13 @@ impl Module {
             },
             &self.default_func_prefix.clone(),
         )? {
-            self.find_functions_from_seeds(
+            self.find_undiscovered_functions(
                 symbol_map,
                 &mut functions_result,
-                &SeededSearchOptions {
-                    end_address: rodata_end,
-                    overriden_function_sizes,
-                    dsprot_encrypted_functions,
+                &FindUndiscoveredFunctionsOptions {
+                    end_address: Some(rodata_end),
+                    overriden_function_sizes: Some(overriden_function_sizes),
+                    dsprot_encrypted_functions: Some(dsprot_encrypted_functions),
                     dsprot_encrypted_ranges,
                 },
             )?;
@@ -994,7 +987,7 @@ impl Module {
             dsprot_encrypted_ranges,
             ..Default::default()
         };
-        let FoundFunctions { functions: text_functions, end: mut text_end, .. } = self
+        let mut functions_result = self
             .find_functions(
                 symbol_map,
                 &FunctionSearchOptions {
@@ -1005,6 +998,17 @@ impl Module {
                 &self.default_func_prefix.clone(),
             )?
             .ok_or_else(|| NoArm9FunctionsSnafu.build())?;
+        self.find_undiscovered_functions(
+            symbol_map,
+            &mut functions_result,
+            &FindUndiscoveredFunctionsOptions {
+                end_address: Some(text_max),
+                overriden_function_sizes: Some(overriden_function_sizes),
+                dsprot_encrypted_functions: Some(dsprot_encrypted_functions),
+                dsprot_encrypted_ranges,
+            },
+        )?;
+        let FoundFunctions { functions: text_functions, end: mut text_end, .. } = functions_result;
 
         let text_start = self.base_address;
         functions.extend(text_functions);
@@ -1203,6 +1207,11 @@ impl Module {
             .ok_or_else(|| NoItcmFunctionsSnafu.build())?;
         // Force .text start to base address for cases where first function is not at the base address
         text_functions.start = self.base_address;
+        self.find_undiscovered_functions(
+            symbol_map,
+            &mut text_functions,
+            &FindUndiscoveredFunctionsOptions::default(),
+        )?;
         let text_end = text_functions.end;
         self.add_text_section(text_functions)?;
 
@@ -1234,18 +1243,24 @@ impl Module {
         };
         let code = autoload.code();
 
-        let (mut functions, mut text_end) = if let Some(f) = self.find_functions(
-            symbol_map,
-            &FunctionSearchOptions {
-                max_function_start_search_distance: 32,
-                use_data_as_upper_bound: true,
-                // There are some handwritten assembly functions in unknown autoloads that don't follow the procedure call standard
-                check_defs_uses: false,
-                ..Default::default()
-            },
-            &self.default_func_prefix.clone(),
-        )? {
-            (f.functions, f.end)
+        let (mut functions, mut text_end) = if let Some(mut functions_result) = self
+            .find_functions(
+                symbol_map,
+                &FunctionSearchOptions {
+                    max_function_start_search_distance: 32,
+                    use_data_as_upper_bound: true,
+                    // There are some handwritten assembly functions in unknown autoloads that don't follow the procedure call standard
+                    check_defs_uses: false,
+                    ..Default::default()
+                },
+                &self.default_func_prefix.clone(),
+            )? {
+            self.find_undiscovered_functions(
+                symbol_map,
+                &mut functions_result,
+                &FindUndiscoveredFunctionsOptions::default(),
+            )?;
+            (functions_result.functions, functions_result.end)
         } else {
             (BTreeMap::new(), self.base_address)
         };
@@ -1538,18 +1553,18 @@ struct FoundFunctions {
     end: u32,
 }
 
-/// Maximum number of passes in [`Module::find_functions_from_seeds`]. Every pass but the last one
-/// discovers at least one function, so this is never reached in practice; the cap only exists so a
-/// future change cannot turn the loop into an infinite one.
-const MAX_SEEDED_SEARCH_PASSES: usize = 100;
+/// Maximum number of passes in [`Module::find_undiscovered_functions`]. Only exists to prevent an
+/// infinite loop and should never be reached in practice.
+const MAX_UNDISCOVERED_SEARCH_PASSES: usize = 100;
 
-/// The [`FunctionSearchOptions`] which [`Module::find_functions_from_seeds`] cannot derive on its
+/// The [`FunctionSearchOptions`] which [`Module::find_undiscovered_functions`] cannot derive on its
 /// own.
-struct SeededSearchOptions<'a> {
+#[derive(Default)]
+struct FindUndiscoveredFunctionsOptions<'a> {
     /// Address to end the search at, i.e. the start of .rodata.
-    end_address: u32,
-    overriden_function_sizes: &'a BTreeMap<u32, u32>,
-    dsprot_encrypted_functions: &'a BTreeMap<u32, dsprot::EncryptionType>,
+    end_address: Option<u32>,
+    overriden_function_sizes: Option<&'a BTreeMap<u32, u32>>,
+    dsprot_encrypted_functions: Option<&'a BTreeMap<u32, dsprot::EncryptionType>>,
     dsprot_encrypted_ranges: &'a [dsprot::EncryptedRange],
 }
 

--- a/lib/src/config/symbol.rs
+++ b/lib/src/config/symbol.rs
@@ -834,7 +834,7 @@ impl<'a, I: Iterator<Item = &'a Vec<SymbolId>>> Iterator for FunctionSymbolItera
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, Debug)]
 pub struct Symbol {
     pub name: String,
     pub kind: SymbolKind,


### PR DESCRIPTION
## Problem

I've been working on decompiling Sonic Colors (BXSE) with dsd and ran into a case the overlay analysis can't handle: the game embeds data tables between functions in overlay .text. In overlay 18 there's about 0x580 bytes of zero padding plus lookup tables at 0x0213F418, and then roughly 52 KB of actual code after them

This breaks init in two ways :

1- The linear function sweep in find_sections_overlay stops at the blob. Pool constants referencing the tables become upper bounds, and the function start search gives up inside non-code (max_function_start_search_distance: 0x10). Everything after the blob gets misclassified as .rodata, and init fails with : "Local function call from 0x0213e6f8 in overlay 18 to 0x0214be64 leads to no function"
The target at 0x0214be64 is a real function though (PUSH {r4-r9, lr} prologue right after the previous function's MOV PC, LR).

2- Even once those functions are in symbols.txt, delink chokes on trampoline functions. A single unconditional B followed directly by data, like 0x0214031C: B 0x2140D28 then a table. Parsing just continues past the branch into the data

I know about the hidden --allow-unknown-function-calls flag, it does get init past the error, but the sections stay misclassified and the functions stay as unknown stubs, so I tried fixing the analysis properly instead

## What this PR does

find_sections_overlay: after the linear sweep, run a second seeded search. Targets of unconditional calls (and of trampoline branches) that aren't covered by a discovered function get analyzed via FunctionSearchOptions::function_addresses, iterating until fixpoint. Since seeds are proven call targets, check_defs_uses is disabled for this pass. Some targets are handwritten assembly reading caller-set registers, like 0x02140B4C starts with cmp r8, #0

find_functions: in seeded mode, a candidate that fails to parse gets skipped instead of terminating the whole search

Function parsing with known_end_address: stop at the known end, and treat branches outside [start, known_end) as tail calls. This lets import_functions re-parse trampolines sitting directly against data

## Testing

All on Sonic Colors (USA ver) :

init now succeeds without --allow-unknown-function-calls. Overlay 18's .text extends 0x0213D7A0..0x0214C2C8 (was cut at 0x0213F418), with the embedded tables left as data inside the code section

delink completes with no warnings, dis works, and rom build from the extract reproduces the original ROM byte-for-byte (SHA1 match), including the DS Protect re-encryption of overlay 17

Also did the full linked roundtrip on my side: lcf to mwldarm to check symbols/check modules (all OK) to rom config to rom build, and SHA1 matches again, cargo test: only test_roundtrip fails, because of the missing local ROM/BIOS assets. Fails the same way on unpatched main. Projects that were initialized with --allow-unknown-function-calls may analyze differently now, since the seeded pass discovers functions the flag used to stub out. Reference configs for those games may need regenerating
Overlays without embedded data are unchanged. The seeded pass only kicks in when undiscovered call targets exist