### PR TITLE
delink: Fix Thumb functions always getting imported despite being local

### DIFF
--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -13,7 +13,7 @@ use ds_decomp::config::{
     module::ModuleKind,
     relocations::RelocationKind,
     section::{MigrateSection, Section, SectionKind},
-    symbol::{InstructionMode, SymFunction, SymbolKind},
+    symbol::{InstructionMode, SymFunction, SymLabel, SymbolKind},
 };
 use ds_rom::rom::{Rom, raw::AutoloadKind};
 use object::{Architecture, BinaryFormat, Endianness, RelocationFlags};
@@ -374,6 +374,7 @@ impl<'a> DelinkObject<'a> {
             let is_thumb = matches!(
                 symbol.kind,
                 SymbolKind::Function(SymFunction { mode: InstructionMode::Thumb, .. })
+                    | SymbolKind::Label(SymLabel { mode: InstructionMode::Thumb, .. })
             );
             let thumb_bit = if is_thumb { 1 } else { 0 };
             self.obj_symbols.insert((symbol.addr | thumb_bit, symbol_module), symbol_id);
@@ -450,7 +451,8 @@ impl<'a> DelinkObject<'a> {
                     };
 
                     // Get destination symbol
-                    let symbol_key = (dest_addr, reloc_module);
+                    let thumb_bit = if relocation.kind().calls_thumb_fn() { 1 } else { 0 };
+                    let symbol_key = (dest_addr | thumb_bit, reloc_module);
                     if let Some(obj_symbol) = self.obj_symbols.get(&symbol_key) {
                         // Use existing symbol
                         *obj_symbol

--- a/cli/src/config/relocation.rs
+++ b/cli/src/config/relocation.rs
@@ -13,6 +13,7 @@ pub trait RelocationKindExt: Sized {
     fn as_obj_symbol_kind(&self) -> object::SymbolKind;
     fn as_elf_relocation_type(&self) -> u32;
     fn from_elf_relocation_type(r_type: u32, dest_thumb: bool, is_branch: bool) -> Option<Self>;
+    fn calls_thumb_fn(&self) -> bool;
 }
 
 impl RelocationKindExt for RelocationKind {
@@ -64,6 +65,18 @@ impl RelocationKindExt for RelocationKind {
             }
             R_ARM_ABS32 => Some(Self::Load),
             _ => None,
+        }
+    }
+
+    fn calls_thumb_fn(&self) -> bool {
+        match self {
+            RelocationKind::ThumbCall | RelocationKind::ArmCallThumb => true,
+            RelocationKind::ArmCall
+            | RelocationKind::ThumbCallArm
+            | RelocationKind::ArmBranch
+            | RelocationKind::Load
+            | RelocationKind::OverlayId
+            | RelocationKind::LinkTimeConst(_) => false,
         }
     }
 }

--- a/cli/src/util/toposort.rs
+++ b/cli/src/util/toposort.rs
@@ -19,12 +19,11 @@ pub fn toposort(graph: &[Vec<usize>]) -> Result<Vec<usize>, Vec<usize>> {
     let mut cur = n;
     loop {
         let State::Active(eind, par) = state[cur] else { panic!("unexpected state 1") };
-        let adj;
-        if cur == n {
+        let adj = if cur == n {
             if eind == n {
                 break;
             }
-            adj = eind;
+            eind
         } else {
             if eind == graph[cur].len() {
                 state[cur] = State::Finished;
@@ -32,7 +31,7 @@ pub fn toposort(graph: &[Vec<usize>]) -> Result<Vec<usize>, Vec<usize>> {
                 cur = par;
                 continue;
             }
-            adj = graph[cur][eind];
+            graph[cur][eind]
         };
         state[cur] = State::Active(eind + 1, par);
         match state[adj] {

--- a/lib/src/analysis/ctor.rs
+++ b/lib/src/analysis/ctor.rs
@@ -152,7 +152,9 @@ impl CtorRange {
         ]);
 
         let num_ctors = code[(ctor_start - arm9.base_address()) as usize..]
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| u32::from_le_bytes([c[0], c[1], c[2], c[3]]))
             .position(|ctor| ctor == 0)
             .unwrap();

--- a/lib/src/analysis/functions.rs
+++ b/lib/src/analysis/functions.rs
@@ -543,7 +543,7 @@ impl Function {
 
         let mut address = base_addr;
         let mut state = SecureAreaState::default();
-        for ins_code in module_code.chunks_exact(2) {
+        for ins_code in module_code.as_chunks::<2>().0 {
             let ins_code = u16::from_le_slice(ins_code);
             let ins = thumb::Ins::new(ins_code as u32, &PARSE_FLAGS);
             let parsed_ins = ins.parse(&PARSE_FLAGS);


### PR DESCRIPTION
`define_section` always sets the least significant bit to 1 for Thumb functions, but `define_relocations` did not set it when looking up local/imported symbols. This meant that Thumb functions weren't allowed to be local because dsd would always trigger the "imported symbol is local" error even if the callers of said Thumb function were in the same delink.