### PR TITLE
check: Add module filter; Fix module filter not filtering overlays and autoloads

### DIFF
--- a/cli/src/cmd/check/modules.rs
+++ b/cli/src/cmd/check/modules.rs
@@ -10,7 +10,10 @@ use ds_decomp::config::{
     module::ModuleKind,
 };
 
-use crate::util::io::{FileError, read_file};
+use crate::{
+    cmd::ModuleFilterArgs,
+    util::io::{FileError, read_file},
+};
 
 /// Verifies that built modules are matching the base ROM.
 #[derive(Args)]
@@ -22,6 +25,9 @@ pub struct CheckModules {
     /// Return failing exit code if a module doesn't pass the checks.
     #[arg(long, short = 'f')]
     pub fail: bool,
+
+    #[command(flatten)]
+    pub module_filter: ModuleFilterArgs,
 }
 
 #[derive(PartialEq, Eq)]
@@ -37,20 +43,27 @@ impl CheckModules {
 
         let mut success = true;
 
-        success &= Self::print_check_module(&config.main_module, ModuleKind::Arm9, config_path)?;
+        if self.module_filter.has(ModuleKind::Arm9) {
+            success &=
+                Self::print_check_module(&config.main_module, ModuleKind::Arm9, config_path)?;
+        }
         for autoload in &config.autoloads {
-            success &= Self::print_check_module(
-                &autoload.module,
-                ModuleKind::Autoload(autoload.kind),
-                config_path,
-            )?;
+            if self.module_filter.has(ModuleKind::Autoload(autoload.kind)) {
+                success &= Self::print_check_module(
+                    &autoload.module,
+                    ModuleKind::Autoload(autoload.kind),
+                    config_path,
+                )?;
+            }
         }
         for overlay in &config.overlays {
-            success &= Self::print_check_module(
-                &overlay.module,
-                ModuleKind::Overlay(overlay.id),
-                config_path,
-            )?;
+            if self.module_filter.has(ModuleKind::Overlay(overlay.id)) {
+                success &= Self::print_check_module(
+                    &overlay.module,
+                    ModuleKind::Overlay(overlay.id),
+                    config_path,
+                )?;
+            }
         }
 
         if self.fail && !success {

--- a/cli/src/cmd/check/symbols.rs
+++ b/cli/src/cmd/check/symbols.rs
@@ -56,7 +56,6 @@ impl CheckSymbols {
         let delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
             migrate_sections: false,
             generate_gap_files: false,
-            module_filter: self.module_filter.build(),
         })?;
         if self.module_filter.has(ModuleKind::Arm9)
             && let Some(target_symbols) = symbol_maps.get(ModuleKind::Arm9)

--- a/cli/src/cmd/check/symbols.rs
+++ b/cli/src/cmd/check/symbols.rs
@@ -10,6 +10,7 @@ use ds_decomp::config::{
 };
 
 use crate::{
+    cmd::ModuleFilterArgs,
     config::{
         delinks::{DelinksMap, DelinksMapOptions},
         symbol::SymbolMapsExt,
@@ -35,6 +36,9 @@ pub struct CheckSymbols {
     /// Maximum number of lines per module to print for each symbol mismatch.
     #[arg(long, short = 'm', default_value_t = 0)]
     pub max_lines: usize,
+
+    #[command(flatten)]
+    pub module_filter: ModuleFilterArgs,
 }
 
 impl CheckSymbols {
@@ -52,9 +56,11 @@ impl CheckSymbols {
         let delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
             migrate_sections: false,
             generate_gap_files: false,
-            module_filter: Vec::new(),
+            module_filter: self.module_filter.build(),
         })?;
-        if let Some(target_symbols) = symbol_maps.get(ModuleKind::Arm9) {
+        if self.module_filter.has(ModuleKind::Arm9)
+            && let Some(target_symbols) = symbol_maps.get(ModuleKind::Arm9)
+        {
             let delinks = delinks_map
                 .get(ModuleKind::Arm9)
                 .context("Symbol map exists for ARM9 main but not delinks")?;
@@ -65,7 +71,9 @@ impl CheckSymbols {
         }
         for autoload in &config.autoloads {
             let module_kind = ModuleKind::Autoload(autoload.kind);
-            if let Some(target_symbols) = symbol_maps.get(module_kind) {
+            if self.module_filter.has(module_kind)
+                && let Some(target_symbols) = symbol_maps.get(module_kind)
+            {
                 let delinks = delinks_map.get(module_kind).with_context(|| {
                     format!("Symbol map exists for {module_kind} but not delinks")
                 })?;
@@ -77,7 +85,9 @@ impl CheckSymbols {
         }
         for overlay in &config.overlays {
             let module_kind = ModuleKind::Overlay(overlay.id);
-            if let Some(target_symbols) = symbol_maps.get(module_kind) {
+            if self.module_filter.has(module_kind)
+                && let Some(target_symbols) = symbol_maps.get(module_kind)
+            {
                 let delinks = delinks_map.get(module_kind).with_context(|| {
                     format!("Symbol map exists for {module_kind} but not delinks")
                 })?;

--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -83,7 +83,6 @@ impl Delink {
         let delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
             migrate_sections: true,
             generate_gap_files: true,
-            module_filter: self.module_filter.build(),
         })?;
 
         let rom = config.load_rom(config_path)?;
@@ -106,32 +105,6 @@ impl Delink {
 }
 
 impl ModuleFilterArgs {
-    pub fn build(&self) -> Vec<ModuleKind> {
-        let mut module_filter = Vec::new();
-        if self.main {
-            module_filter.push(ModuleKind::Arm9);
-        }
-        module_filter.extend(
-            self.overlay
-                .iter()
-                .filter(|&id| self.overlay.contains(id))
-                .map(|&id| ModuleKind::Overlay(id)),
-        );
-        if self.itcm {
-            module_filter.push(ModuleKind::Autoload(AutoloadKind::Itcm));
-        }
-        if self.dtcm {
-            module_filter.push(ModuleKind::Autoload(AutoloadKind::Dtcm));
-        }
-        module_filter.extend(
-            self.autoload
-                .iter()
-                .filter(|&index| self.autoload.contains(index))
-                .map(|&index| ModuleKind::Autoload(AutoloadKind::Unknown(index))),
-        );
-        module_filter
-    }
-
     pub fn all() -> Self {
         Self::default()
     }

--- a/cli/src/cmd/delink.rs
+++ b/cli/src/cmd/delink.rs
@@ -111,7 +111,12 @@ impl ModuleFilterArgs {
         if self.main {
             module_filter.push(ModuleKind::Arm9);
         }
-        module_filter.extend(self.overlay.iter().map(|&id| ModuleKind::Overlay(id)));
+        module_filter.extend(
+            self.overlay
+                .iter()
+                .filter(|&id| self.overlay.contains(id))
+                .map(|&id| ModuleKind::Overlay(id)),
+        );
         if self.itcm {
             module_filter.push(ModuleKind::Autoload(AutoloadKind::Itcm));
         }
@@ -119,7 +124,10 @@ impl ModuleFilterArgs {
             module_filter.push(ModuleKind::Autoload(AutoloadKind::Dtcm));
         }
         module_filter.extend(
-            self.autoload.iter().map(|&index| ModuleKind::Autoload(AutoloadKind::Unknown(index))),
+            self.autoload
+                .iter()
+                .filter(|&index| self.autoload.contains(index))
+                .map(|&index| ModuleKind::Autoload(AutoloadKind::Unknown(index))),
         );
         module_filter
     }

--- a/cli/src/cmd/diff/apply.rs
+++ b/cli/src/cmd/diff/apply.rs
@@ -411,7 +411,6 @@ fn apply_actions<'a>(
     let mut delinks_map = DelinksMap::from_config(config, config_path, DelinksMapOptions {
         migrate_sections: false,
         generate_gap_files: false,
-        module_filter: Vec::new(),
     })?;
     let mut symbol_maps = SymbolMaps::from_config(config_path, config)?;
     let mut relocations_map = RelocationsMap::from_config(config, config_path)?;

--- a/cli/src/cmd/diff/new.rs
+++ b/cli/src/cmd/diff/new.rs
@@ -130,11 +130,8 @@ struct ProjectInfo {
 
 impl ProjectInfo {
     fn new(config: &Config, config_path: &Path, rom: &Rom) -> Result<Self> {
-        let delinks_map_options = DelinksMapOptions {
-            migrate_sections: false,
-            generate_gap_files: false,
-            module_filter: Vec::new(),
-        };
+        let delinks_map_options =
+            DelinksMapOptions { migrate_sections: false, generate_gap_files: false };
         Ok(ProjectInfo {
             delinks_map: DelinksMap::from_config(config, config_path, delinks_map_options)?,
             program: Program::from_config(config_path, config, rom)?,

--- a/cli/src/cmd/dis.rs
+++ b/cli/src/cmd/dis.rs
@@ -55,7 +55,6 @@ impl Disassemble {
             // deleted by the other.
             migrate_sections: false,
             generate_gap_files: true,
-            module_filter: self.module_filter.build(),
         })?;
 
         let rom = config.load_rom(config_path)?;

--- a/cli/src/cmd/fix/ctor_zero.rs
+++ b/cli/src/cmd/fix/ctor_zero.rs
@@ -44,7 +44,6 @@ impl FixCtorZero {
         let mut delinks_map = DelinksMap::from_config(&config, config_path, DelinksMapOptions {
             migrate_sections: false,
             generate_gap_files: false,
-            module_filter: Vec::new(),
         })?;
         let mut symbol_maps = SymbolMaps::from_config(config_path, &config)?;
         let mut relocs_map = RelocationsMap::from_config(&config, config_path)?;

--- a/cli/src/cmd/json/delinks.rs
+++ b/cli/src/cmd/json/delinks.rs
@@ -53,7 +53,6 @@ impl JsonDelinks {
             // call `DelinksMap::delink_files()` later
             migrate_sections: false,
             generate_gap_files: true,
-            module_filter: Vec::new(),
         })?;
 
         let files = delinks_map

--- a/cli/src/cmd/lcf.rs
+++ b/cli/src/cmd/lcf.rs
@@ -105,7 +105,6 @@ impl Lcf {
             // We want migrated sections to be linked in the module it belongs to
             migrate_sections: true,
             generate_gap_files: true,
-            module_filter: Vec::new(),
         })?;
         Self::validate_all_file_names(&delinks_map)?;
 

--- a/cli/src/cmd/objdiff.rs
+++ b/cli/src/cmd/objdiff.rs
@@ -89,7 +89,6 @@ impl Objdiff {
             // unit.
             migrate_sections: false,
             generate_gap_files: true,
-            module_filter: Vec::new(),
         })?;
 
         let mut units = Vec::new();

--- a/cli/src/config/delinks.rs
+++ b/cli/src/config/delinks.rs
@@ -298,9 +298,6 @@ pub struct DelinksMap {
 pub struct DelinksMapOptions {
     pub migrate_sections: bool,
     pub generate_gap_files: bool,
-    /// If non-empty, only load these modules. Note that ARM9 main and autoload modules will always
-    /// be loaded so that sections like .dtcm, .itcm and .exception may be migrated.
-    pub module_filter: Vec<ModuleKind>,
 }
 
 impl DelinksMap {
@@ -312,11 +309,6 @@ impl DelinksMap {
         let path = path.as_ref();
         let map = config
             .iter_modules()
-            .filter(|(kind, _)| {
-                options.module_filter.is_empty()
-                    || matches!(kind, ModuleKind::Arm9 | ModuleKind::Autoload(_))
-                    || options.module_filter.contains(kind)
-            })
             .map(|(kind, config)| {
                 let delinks = Delinks::from_file(path.join(&config.delinks), kind)?;
                 Ok((kind, delinks))

--- a/cli/tests/test_roundtrip.rs
+++ b/cli/tests/test_roundtrip.rs
@@ -160,12 +160,17 @@ fn test_roundtrip() -> Result<()> {
             fail: true,
             elf_path: linker_out_file.clone(),
             max_lines: 3,
+            module_filter: ModuleFilterArgs::all(),
         };
         check_symbols.run()?;
 
         // Check modules
         log::info!("Running dsd check modules...");
-        let check_modules = CheckModules { config_path: dsd_config_yaml.clone(), fail: true };
+        let check_modules = CheckModules {
+            config_path: dsd_config_yaml.clone(),
+            fail: true,
+            module_filter: ModuleFilterArgs::all(),
+        };
         check_modules.run()?;
 
         // Configure ds-rom


### PR DESCRIPTION
The `check modules` and `check symbols` commands now have the same module filter arguments as `delink` and `dis`.

In addition, a bug was fixed in `dsd delink` which caused different output based on which modules were filtered. For example, if an overlay delink declares `.dtcm` and migrates from the DTCM's `.bss`, and the build system decides to delink only DTCM (i.e. `dsd delink --dtcm`), then that portion of `.bss` would remain in its place when it should have been excluded.

`dsd delink` will still be delinking only the specified modules, but all delinks.txt files will be read and checked for migrations.